### PR TITLE
Add x509 parsing utilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/notaryproject/notation-core-go
+
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/notaryproject/notation-core-go
 
-go 1.18
+go 1.17

--- a/x509/cert.go
+++ b/x509/cert.go
@@ -1,0 +1,31 @@
+package cryptoutil
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+)
+
+// ReadCertificateFile reads a certificate PEM file.
+func ReadCertificateFile(path string) ([]*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCertificatePEM(data)
+}
+
+// ParseCertificatePEM parses a certificate PEM.
+func ParseCertificatePEM(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	block, rest := pem.Decode(data)
+	for block != nil {
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+		block, rest = pem.Decode(rest)
+	}
+	return certs, nil
+}

--- a/x509/cert.go
+++ b/x509/cert.go
@@ -15,7 +15,8 @@ func ReadCertificateFile(path string) ([]*x509.Certificate, error) {
 	return ParseCertificatePEM(data)
 }
 
-// ParseCertificatePEM parses a certificate PEM.
+// ParseCertificatePEM parses a certificate PEM,
+// Does not perform any additional validations if the certs are a valid cert chain.
 func ParseCertificatePEM(data []byte) ([]*x509.Certificate, error) {
 	var certs []*x509.Certificate
 	block, rest := pem.Decode(data)

--- a/x509/key.go
+++ b/x509/key.go
@@ -1,0 +1,36 @@
+package cryptoutil
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ReadPrivateKeyFile reads a key PEM file as a signing key.
+func ReadPrivateKeyFile(path string) (crypto.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePrivateKeyPEM(data)
+}
+
+// ParsePrivateKeyPEM parses a PEM as a signing key.
+func ParsePrivateKeyPEM(data []byte) (crypto.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("no PEM data found")
+	}
+	switch block.Type {
+	case "PRIVATE KEY":
+		return x509.ParsePKCS8PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	}
+	return nil, fmt.Errorf("unsupported PEM block type: %s", block.Type)
+}


### PR DESCRIPTION
* Moving x509 cert, key parsing utilities from notation-go to notation-core-go
* Will raise a separate PR for refactoring notation-go and notation repos

Signed-off-by: rgnote <5878554+rgnote@users.noreply.github.com>