### PR TITLE
Abstract out signature generation and verification to SignatureEnvelope

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/notaryproject/notation-core-go
 
 go 1.17
+
+require github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/internal/crypto/hashutil/hash.go
+++ b/internal/crypto/hashutil/hash.go
@@ -1,7 +1,11 @@
 // Package hashutil provides utilities for hash.
 package hashutil
 
-import "crypto"
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+)
 
 // ComputeHash computes the digest of the message with the given hash algorithm.
 // Callers should check the availability of the hash algorithm before invoking.
@@ -12,4 +16,30 @@ func ComputeHash(hash crypto.Hash, message []byte) ([]byte, error) {
 		return nil, err
 	}
 	return h.Sum(nil), nil
+}
+
+// GetHasher picks up a recommended hashing algorithm for given public keys.
+func GetHasher(pubKey crypto.PublicKey) (crypto.Hash, bool) {
+	var hash crypto.Hash
+	switch key := pubKey.(type) {
+	case *rsa.PublicKey:
+		switch key.Size() {
+		case 256:
+			hash = crypto.SHA256
+		case 384:
+			hash = crypto.SHA384
+		case 512:
+			hash = crypto.SHA512
+		}
+	case *ecdsa.PublicKey:
+		switch key.Curve.Params().BitSize {
+		case 256:
+			hash = crypto.SHA256
+		case 384:
+			hash = crypto.SHA384
+		case 521:
+			hash = crypto.SHA512
+		}
+	}
+	return hash, hash.Available()
 }

--- a/internal/testhelper/certificatetest.go
+++ b/internal/testhelper/certificatetest.go
@@ -1,0 +1,149 @@
+// Package testhelper implements utility routines required for writing unit tests.
+// The testhelper should only be used in unit tests.
+package testhelper
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"time"
+)
+
+var (
+	rsaRoot     CertTuple
+	rsaLeaf     CertTuple
+	ecdsaRoot   ECCertTuple
+	ecdsaLeaf   ECCertTuple
+	unsupported CertTuple
+)
+
+type CertTuple struct {
+	Cert       *x509.Certificate
+	PrivateKey *rsa.PrivateKey
+}
+
+type ECCertTuple struct {
+	Cert       *x509.Certificate
+	PrivateKey *ecdsa.PrivateKey
+}
+
+// init runs before any other part of this package.
+func init() {
+	setupCertificates()
+}
+
+// GetRSARootCertificate returns root certificate signed using RSA algorithm
+func GetRSARootCertificate() CertTuple {
+	return rsaRoot
+}
+
+// GetRSALeafCertificate returns leaf certificate signed using RSA algorithm
+func GetRSALeafCertificate() CertTuple {
+	return rsaLeaf
+}
+
+// GetECRootCertificate returns root certificate signed using EC algorithm
+func GetECRootCertificate() ECCertTuple {
+	return ecdsaRoot
+}
+
+// GetECLeafCertificate returns leaf certificate signed using EC algorithm
+func GetECLeafCertificate() ECCertTuple {
+	return ecdsaLeaf
+}
+
+// GetUnsupportedCertificate returns certificate signed using RSA algorithm with key size of 1024 bits
+// which is not supported by notary.
+func GetUnsupportedCertificate() CertTuple {
+	return unsupported
+}
+
+func setupCertificates() {
+	rsaRoot = getCertTuple("Notation Test Root", nil)
+	rsaLeaf = getCertTuple("Notation Test Leaf Cert", &rsaRoot)
+	ecdsaRoot = getECCertTuple("Notation Test Root2", nil)
+	ecdsaLeaf = getECCertTuple("Notation Test Leaf Cert", &ecdsaRoot)
+
+	// This will be flagged by the static code analyzer as 'Use of a weak cryptographic key' but its intentional
+	// and is used only for testing.
+	k, _ := rsa.GenerateKey(rand.Reader, 1024)
+	unsupported = getRSACertTupleWithPK(k, "Notation Unsupported Root", nil)
+}
+
+func getCertTuple(cn string, issuer *CertTuple) CertTuple {
+	pk, _ := rsa.GenerateKey(rand.Reader, 3072)
+	return getRSACertTupleWithPK(pk, cn, issuer)
+}
+
+func getECCertTuple(cn string, issuer *ECCertTuple) ECCertTuple {
+	k, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	return getECDSACertTupleWithPK(k, cn, issuer)
+}
+
+func getRSACertTupleWithPK(privKey *rsa.PrivateKey, cn string, issuer *CertTuple) CertTuple {
+	template := getCertTemplate(issuer == nil, cn)
+
+	var certBytes []byte
+	if issuer != nil {
+		certBytes, _ = x509.CreateCertificate(rand.Reader, template, issuer.Cert, &privKey.PublicKey, issuer.PrivateKey)
+	} else {
+		certBytes, _ = x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
+	}
+
+	cert, _ := x509.ParseCertificate(certBytes)
+	return CertTuple{
+		Cert:       cert,
+		PrivateKey: privKey,
+	}
+}
+
+func getECDSACertTupleWithPK(privKey *ecdsa.PrivateKey, cn string, issuer *ECCertTuple) ECCertTuple {
+	template := getCertTemplate(issuer == nil, cn)
+
+	var certBytes []byte
+	if issuer != nil {
+		certBytes, _ = x509.CreateCertificate(rand.Reader, template, issuer.Cert, &privKey.PublicKey, issuer.PrivateKey)
+	} else {
+		certBytes, _ = x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
+	}
+
+	cert, _ := x509.ParseCertificate(certBytes)
+	return ECCertTuple{
+		Cert:       cert,
+		PrivateKey: privKey,
+	}
+}
+
+func getCertTemplate(isRoot bool, cn string) *x509.Certificate {
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			Organization: []string{"Notary"},
+			Country:      []string{"US"},
+			Province:     []string{"WA"},
+			Locality:     []string{"Seattle"},
+			CommonName:   cn,
+		},
+		NotBefore:   time.Now(),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+	}
+	if isRoot {
+		template.SerialNumber = big.NewInt(1)
+		template.NotAfter = time.Now().AddDate(0, 1, 0)
+		template.KeyUsage = x509.KeyUsageCertSign
+		template.BasicConstraintsValid = true
+		template.MaxPathLen = 1
+		template.IsCA = true
+	} else {
+		template.SerialNumber = big.NewInt(2)
+		template.NotAfter = time.Now().AddDate(0, 0, 1)
+		template.KeyUsage = x509.KeyUsageDigitalSignature
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning}
+	}
+
+	return template
+}

--- a/signer/errors.go
+++ b/signer/errors.go
@@ -1,0 +1,103 @@
+package signer
+
+import "fmt"
+
+// SignatureIntegrityError is used when the Signature associated is no longer valid.
+type SignatureIntegrityError struct {
+	err error
+}
+
+func (e SignatureIntegrityError) Error() string {
+	return fmt.Sprintf("signature is invalid. Error: %s", e.err.Error())
+}
+
+// MalformedSignatureError is used when Signature envelope is malformed.
+type MalformedSignatureError struct {
+	msg string
+}
+
+func (e MalformedSignatureError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+	return "signature envelope format is malformed"
+
+}
+
+// UnsupportedSignatureFormatError is used when Signature envelope is not supported.
+type UnsupportedSignatureFormatError struct {
+	mediaType string
+}
+
+func (e UnsupportedSignatureFormatError) Error() string {
+	return fmt.Sprintf("signature envelope format with media type %q is not supported", e.mediaType)
+}
+
+// SignatureNotFoundError is used when signature envelope is not present.
+type SignatureNotFoundError struct{}
+
+func (e SignatureNotFoundError) Error() string {
+	return "signature envelope is not present"
+}
+
+// SignatureAuthenticityError is used when signature is not generated using trusted certificates.
+type SignatureAuthenticityError struct{}
+
+func (e SignatureAuthenticityError) Error() string {
+	return "signature is not produced by a trusted signer"
+}
+
+// UnsupportedOperationError is used when an operation is not supported.
+type UnsupportedOperationError struct {
+	operation string
+}
+
+func (e UnsupportedOperationError) Error() string {
+	return fmt.Sprintf("%q operation is not supported", e.operation)
+}
+
+// UnsupportedSigningKeyError is used when a signing key is not supported
+type UnsupportedSigningKeyError struct {
+	keyType string
+}
+
+func (e UnsupportedSigningKeyError) Error() string {
+	if e.keyType != "" {
+		return fmt.Sprintf("%q signing key is not supported", e.keyType)
+	}
+	return "signing key is not supported"
+}
+
+// MalformedArgumentError is used when an argument to a function is malformed.
+type MalformedArgumentError struct {
+	param string
+	err   error
+}
+
+func (e MalformedArgumentError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%q param is malformed. Error: %s", e.param, e.err.Error())
+	}
+	return fmt.Sprintf("%q param is malformed", e.param)
+}
+
+// MalformedSignRequestError is used when SignRequest is malformed.
+type MalformedSignRequestError struct {
+	msg string
+}
+
+func (e MalformedSignRequestError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+	return "SignRequest is malformed"
+}
+
+// SignatureAlgoNotSupportedError is used when signing algo is not supported.
+type SignatureAlgoNotSupportedError struct {
+	alg string
+}
+
+func (e SignatureAlgoNotSupportedError) Error() string {
+	return fmt.Sprintf("signature algorithm %q is not supported", e.alg)
+}

--- a/signer/jws.go
+++ b/signer/jws.go
@@ -1,0 +1,392 @@
+package signer
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const (
+	MediaTypeJWSJson SignatureMediaType = "application/jose+json"
+)
+
+const (
+	headerKeyExpiry      = "io.cncf.notary.expiry"
+	headerKeySigningTime = "io.cncf.notary.signingTime"
+	headerKeyCrit        = "crit"
+	headerKeyAlg         = "alg"
+	headerKeyCty         = "cty"
+)
+
+// jwsEnvelope represents implements internalSignatureEnvelope interface.
+type jwsEnvelope struct {
+	internalEnv *jwsInternalEnvelope
+}
+
+func newJWSEnvelopeFromBytes(envelopeBytes []byte) (*jwsEnvelope, error) {
+	jwsInternal, err := newJwsInternalEnvelopeFromBytes(envelopeBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jwsEnvelope{internalEnv: jwsInternal}, nil
+}
+
+func (jws *jwsEnvelope) validateIntegrity() error {
+	if jws.internalEnv == nil {
+		return SignatureNotFoundError{}
+	}
+
+	if len(jws.internalEnv.Header.CertChain) == 0 {
+		return MalformedSignatureError{msg: "malformed leaf certificate"}
+	}
+
+	cert, err := x509.ParseCertificate(jws.internalEnv.Header.CertChain[0])
+	if err != nil {
+		return MalformedSignatureError{msg: "malformed leaf certificate"}
+	}
+
+	// verify JWT
+	compact := strings.Join([]string{jws.internalEnv.Protected, jws.internalEnv.Payload, jws.internalEnv.Signature}, ".")
+	return verifyJWT(compact, cert.PublicKey)
+}
+
+func (jws *jwsEnvelope) signPayload(req SignRequest) ([]byte, error) {
+	leafPublicKey := req.CertificateChain[0].PublicKey
+	var m map[string]interface{}
+	if err := json.Unmarshal(req.Payload, &m); err != nil {
+		return nil, err
+	}
+	signingMethod, err := getSigningMethod(leafPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	signedAttrs, err := getSignedAttrs(req, signingMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	compact, err := signJWT(m, signedAttrs, signingMethod, req.SignatureProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	j, err := generateJws(compact, req)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(j)
+	if err != nil {
+		return nil, err
+	}
+	jws.internalEnv = j
+	return b, nil
+}
+
+func (jws *jwsEnvelope) getSignerInfo() (*SignerInfo, error) {
+	signInfo := SignerInfo{}
+	if jws.internalEnv == nil {
+		return nil, SignatureNotFoundError{}
+	}
+
+	// parse payload
+	payload, err := base64.RawURLEncoding.DecodeString(jws.internalEnv.Payload)
+	if err != nil {
+		return nil, err
+	}
+	signInfo.Payload = payload
+
+	// parse protected headers
+	protected, err := parseProtectedHeaders(jws.internalEnv.Protected)
+	if err != nil {
+		return nil, err
+	}
+	if err := populateProtectedHeaders(protected, &signInfo); err != nil {
+		return nil, err
+	}
+
+	// parse signature
+	sig, err := base64.RawURLEncoding.DecodeString(jws.internalEnv.Signature)
+	if err != nil {
+		return nil, err
+	}
+	signInfo.Signature = sig
+
+	// parse headers
+	var certs []*x509.Certificate
+	for _, certBytes := range jws.internalEnv.Header.CertChain {
+		cert, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+	signInfo.CertificateChain = certs
+	signInfo.UnsignedAttributes.SigningAgent = jws.internalEnv.Header.SigningAgent
+	signInfo.TimestampSignature = jws.internalEnv.Header.TimestampSignature
+
+	return &signInfo, nil
+}
+
+func parseProtectedHeaders(encoded string) (*jwsProtectedHeader, error) {
+	rawProtected, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, MalformedSignatureError{msg: fmt.Sprintf("jws envelope protected header can't be decoded: %s", err.Error())}
+	}
+
+	var protected jwsProtectedHeader
+	if err = json.Unmarshal(rawProtected, &protected); err != nil {
+		return nil, MalformedSignatureError{msg: fmt.Sprintf("jws envelope protected header can't be decoded: %s", err.Error())}
+	}
+	if err = json.Unmarshal(rawProtected, &protected.ExtendedAttributes); err != nil {
+		return nil, MalformedSignatureError{msg: fmt.Sprintf("jws envelope protected header can't be decoded: %s", err.Error())}
+	}
+
+	// delete attributes that are already defined in jwsProtectedHeader.
+	delete(protected.ExtendedAttributes, headerKeyAlg)
+	delete(protected.ExtendedAttributes, headerKeyCty)
+	delete(protected.ExtendedAttributes, headerKeyCrit)
+	delete(protected.ExtendedAttributes, headerKeySigningTime)
+	delete(protected.ExtendedAttributes, headerKeyExpiry)
+
+	return &protected, nil
+}
+
+func populateProtectedHeaders(pHeader *jwsProtectedHeader, signInfo *SignerInfo) error {
+	err := validateCriticalHeaders(pHeader)
+	if err != nil {
+		return err
+	}
+
+	if signInfo.SignatureAlgorithm, err = getAlgo(pHeader.Algorithm); err != nil {
+		return err
+	}
+
+	signInfo.PayloadContentType = pHeader.ContentType
+	signInfo.SignedAttributes.SigningTime = pHeader.SigningTime.Truncate(time.Second)
+	signInfo.SignedAttributes.Expiry = pHeader.Expiry.Truncate(time.Second)
+	signInfo.SignedAttributes.ExtendedAttributes = getExtendedAttributes(pHeader.ExtendedAttributes, pHeader.Critical)
+	return nil
+}
+
+func getExtendedAttributes(attrs map[string]interface{}, critical []string) []Attribute {
+	extendedAttr := make([]Attribute, 0, len(attrs))
+	for key, value := range attrs {
+		extendedAttr = append(extendedAttr, Attribute{
+			Key:      key,
+			Critical: contains(critical, key),
+			Value:    value,
+		})
+	}
+	return extendedAttr
+}
+
+func validateCriticalHeaders(pheader *jwsProtectedHeader) error {
+	if len(pheader.Critical) == 0 {
+		return MalformedSignatureError{"missing `crit` header"}
+	}
+
+	mustMarkedCrit := map[string]bool{}
+	if !pheader.Expiry.IsZero() {
+		mustMarkedCrit[headerKeyExpiry] = true
+	}
+
+	for _, val := range pheader.Critical {
+		if _, ok := mustMarkedCrit[val]; ok {
+			delete(mustMarkedCrit, val)
+		} else {
+			if _, ok := pheader.ExtendedAttributes[val]; !ok {
+				return MalformedSignatureError{msg: fmt.Sprintf("%q header is marked critical but not present", val)}
+			}
+		}
+	}
+
+	// validate all required critical headers are present.
+	if len(mustMarkedCrit) != 0 {
+		// This is not taken care by VerifySignerInfo method
+		return MalformedSignatureError{"required headers not marked critical"}
+	}
+
+	return nil
+}
+
+func getSignedAttrs(req SignRequest, method jwt.SigningMethod) (map[string]interface{}, error) {
+	extAttrs := make(map[string]interface{})
+	var crit []string
+	if !req.Expiry.IsZero() {
+		crit = append(crit, headerKeyExpiry)
+	}
+
+	for _, elm := range req.ExtendedSignedAttrs {
+		extAttrs[elm.Key] = elm.Value
+		if elm.Critical {
+			crit = append(crit, elm.Key)
+		}
+	}
+
+	pHeader := jwsProtectedHeader{
+		Algorithm:   method.Alg(),
+		ContentType: req.PayloadContentType,
+		Critical:    crit,
+		SigningTime: req.SigningTime.Truncate(time.Second),
+	}
+	if !req.Expiry.IsZero() {
+		pHeader.Expiry = req.Expiry.Truncate(time.Second)
+	}
+
+	m, err := convertToMap(pHeader)
+	if err != nil {
+		return nil, MalformedSignRequestError{msg: fmt.Sprintf("unexpected error occured while creating protected headers, Error: %s", err.Error())}
+	}
+
+	return mergeMaps(m, extAttrs), nil
+}
+
+// ***********************************************************************
+// jwsEnvelope-JSON specific code
+// ***********************************************************************
+const (
+	// PayloadContentTypeJWSV1 describes the media type of the jwsEnvelope envelope.
+	PayloadContentTypeJWSV1 = "application/vnd.cncf.notary.v2.jws.v1"
+)
+
+// jwsInternalEnvelope is the final Signature envelope.
+type jwsInternalEnvelope struct {
+	// JWSPayload Base64URL-encoded.
+	Payload string `json:"payload"`
+
+	// jwsProtectedHeader Base64URL-encoded.
+
+	Protected string `json:"protected"`
+
+	// Signature metadata that is not integrity Protected
+	Header jwsUnprotectedHeader `json:"header"`
+
+	// Base64URL-encoded Signature.
+	Signature string `json:"signature"`
+}
+
+// jwsProtectedHeader contains the set of protected headers.
+type jwsProtectedHeader struct {
+	// Defines which algorithm was used to generate the signature.
+	Algorithm string `json:"alg"`
+
+	// Media type of the secured content (the payload).
+	ContentType string `json:"cty"`
+
+	// Lists the headers that implementation MUST understand and process.
+	Critical []string `json:"crit"`
+
+	// The time at which the signature was generated.
+	SigningTime time.Time `json:"io.cncf.notary.signingTime"`
+
+	// The "best by use" time for the artifact, as defined by the signer.
+	Expiry time.Time `json:"io.cncf.notary.expiry,omitempty"`
+
+	// The user defined attributes.
+	ExtendedAttributes map[string]interface{} `json:"-"`
+}
+
+// jwsUnprotectedHeader contains the set of unprotected headers.
+type jwsUnprotectedHeader struct {
+	// RFC3161 time stamp token Base64-encoded.
+	TimestampSignature []byte `json:"io.cncf.notary.TimestampSignature,omitempty"`
+
+	// List of X.509 Base64-DER-encoded certificates
+	// as defined at https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6.
+	CertChain [][]byte `json:"x5c"`
+
+	// SigningAgent used for signing
+	SigningAgent string `json:"io.cncf.notary.SigningAgent,omitempty"`
+}
+
+func newJwsInternalEnvelopeFromBytes(b []byte) (*jwsInternalEnvelope, error) {
+	var jws jwsInternalEnvelope
+	if err := json.Unmarshal(b, &jws); err != nil {
+		return nil, err
+	}
+	return &jws, nil
+}
+
+func generateJws(compact string, req SignRequest) (*jwsInternalEnvelope, error) {
+	parts := strings.Split(compact, ".")
+	if len(parts) != 3 {
+		// this should never happen
+		return nil, errors.New("unexpected error while generating a JWS-JSON serialization from compact serialization")
+	}
+
+	rawCerts := make([][]byte, len(req.CertificateChain))
+	for i, cert := range req.CertificateChain {
+		rawCerts[i] = cert.Raw
+	}
+
+	return &jwsInternalEnvelope{
+		Protected: parts[0],
+		Payload:   parts[1],
+		Signature: parts[2],
+		Header: jwsUnprotectedHeader{
+			CertChain:    rawCerts,
+			SigningAgent: req.SigningAgent,
+		},
+	}, nil
+}
+
+func getAlgo(alg string) (SignatureAlgorithm, error) {
+	switch alg {
+	case "PS256":
+		return RSASSA_PSS_SHA_256, nil
+	case "PS384":
+		return RSASSA_PSS_SHA_384, nil
+	case "PS512":
+		return RSASSA_PSS_SHA_512, nil
+	case "ES256":
+		return ECDSA_SHA_256, nil
+	case "ES384":
+		return ECDSA_SHA_384, nil
+	case "ES512":
+		return ECDSA_SHA_512, nil
+	}
+
+	return RSASSA_PSS_SHA_512, SignatureAlgoNotSupportedError{alg: alg}
+}
+
+func convertToMap(i interface{}) (map[string]interface{}, error) {
+	s, err := json.Marshal(i)
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(s, &m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func mergeMaps(maps ...map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/signer/jws_test.go
+++ b/signer/jws_test.go
@@ -1,0 +1,174 @@
+package signer
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/notaryproject/notation-core-go/internal/testhelper"
+)
+
+// Tests various scenarios around newJWSEnvelopeFromBytes method
+func TestNewJWSEnvelopeFromBytes(t *testing.T) {
+	t.Run("newJWSEnvelopeFromBytes", func(t *testing.T) {
+		if _, err := newJWSEnvelopeFromBytes([]byte(TestValidSig)); err != nil {
+			t.Errorf("Error found: %q", err)
+		}
+	})
+
+	t.Run("newJWSEnvelopeFromBytes Error", func(t *testing.T) {
+		if _, err := newJWSEnvelopeFromBytes([]byte("Malformed")); err == nil {
+			t.Errorf("Expected error but not found")
+		}
+	})
+}
+
+// Tests various scenarios around validateIntegrity method
+func TestValidateIntegrity(t *testing.T) {
+	t.Run("with newJWSEnvelope() returns error", func(t *testing.T) {
+		env := jwsEnvelope{}
+		err := env.validateIntegrity()
+		if !(err != nil && errors.As(err, new(SignatureNotFoundError))) {
+			t.Errorf("Expected SignatureNotFoundError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with NewJWSEnvelopeFromBytes works", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte(TestValidSig))
+		err := env.validateIntegrity()
+		if err != nil {
+			t.Errorf("validateIntegrity(). Error = %s", err)
+		}
+	})
+
+	t.Run("with invalid base64 bytes sig envelope returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"Hi!\",\"Protected\":\"Hi\",\"Header\":{},\"Signature\":\"Hi!\"}"))
+		err := env.validateIntegrity()
+		if !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected MalformedSignatureError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with incomplete sig envelope returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"eyJhbGciOiJIUzI1NiJ9\",\"Protected\":\"eyJhbGciOiJQUzI1NiIsImNyaXQiOlsiaW8uY25jZi5ub3Rhcnkuc2lnbmluZ1RpbWUiXSwiaW8uY25jZi5ub3Rhcnkuc2luaW5nVGltZSI6IjIwMDYtMDEtMDJUMTU6MDQ6MDVaIn0\",\"Header\":{},\"Signature\":\"YjGj\"}"))
+		if err := env.validateIntegrity(); !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected MalformedSignatureError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with tempered payload returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte(TestTamperedSig))
+		if err := env.validateIntegrity(); !(err != nil && errors.As(err, new(SignatureIntegrityError))) {
+			t.Errorf("Expected SignatureIntegrityError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with tempered certificate returns error", func(t *testing.T) {
+		var jwsInternal jwsInternalEnvelope
+		json.Unmarshal([]byte(TestValidSig), &jwsInternal)
+		jwsInternal.Header.CertChain[0] = testhelper.GetRSALeafCertificate().Cert.Raw
+		tempered, _ := json.Marshal(jwsInternal)
+		env, _ := newJWSEnvelopeFromBytes(tempered)
+		if err := env.validateIntegrity(); !(err != nil && errors.As(err, new(SignatureIntegrityError))) {
+			t.Errorf("Expected SignatureIntegrityError but found %q", reflect.TypeOf(err))
+		}
+	})
+}
+
+// Tests various scenarios around getSignerInfo method
+func TestGetSignerInfo(t *testing.T) {
+	t.Run("with newJWSEnvelope before sign returns error", func(t *testing.T) {
+		env := jwsEnvelope{}
+		_, err := env.getSignerInfo()
+		if !(err != nil && errors.As(err, new(SignatureNotFoundError))) {
+			t.Errorf("Expected SignatureNotFoundError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with newJWSEnvelope after sign works", func(t *testing.T) {
+		env := jwsEnvelope{}
+		env.signPayload(getSignRequest())
+		_, err := env.getSignerInfo()
+		if err != nil {
+			t.Errorf("getSignerInfo(). Error = %s", err)
+		}
+	})
+
+	t.Run("with NewJWSEnvelopeFromBytes works", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte(TestValidSig))
+		_, err := env.getSignerInfo()
+		if err != nil {
+			t.Errorf("getSignerInfo(). Error = %s", err)
+		}
+	})
+
+	t.Run("with invalid base64 bytes sig envelope returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"Hi!\",\"Protected\":\"Hi\",\"Header\":{},\"Signature\":\"Hi!\"}"))
+		if _, err := env.getSignerInfo(); err == nil {
+			t.Errorf("Expected error but not found")
+		}
+	})
+
+	t.Run("with invalid singing time returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"eyJhbGciOiJIUzI1NiJ9\",\"Protected\":\"eyJhbGciOiJQUzI1NiIsImNyaXQiOlsiaW8uY25jZi5ub3Rhcnkuc2lnbmluZ1RpbWUiXSwiaW8uY25jZi5ub3Rhcnkuc2lnbmluZ1RpbWUiOiIyMDA2LS0wMlQxNTowNDowNVoifQ\"" +
+			",\"Header\":{},\"Signature\":\"YjGj\"}"))
+		if _, err := env.getSignerInfo(); !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected MalformedSignatureError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with missing crit header returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"eyJhbGciOiJIUzI1NiJ9\",\"Protected\":\"eyJpc3MiOiJEaW5vQ2hpZXNhLmdpdGh1Yi5pbyIsInN1YiI6Im9sYWYiLCJhdWQiOiJhdWRyZXkiLCJpYXQiOjE2NTQ1ODYyODIsImV4cCI6MTY1NDU4Njg4Mn0\"" +
+			",\"Header\":{},\"Signature\":\"YjGj\"}"))
+		if _, err := env.getSignerInfo(); !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected MalformedSignatureError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with malformed alg header returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"eyJhbGciOiJIUzI1NiJ9\",\"Protected\":\"eyJhbGciOjEzLCJjcml0IjpbImlvLmNuY2Yubm90YXJ5LnNpZ25pbmdUaW1lIl0sImlvLmNuY2Yubm90YXJ5LnNpbmluZ1RpbWUiOiIyMDA2LTAxLTAyVDE1OjA0OjA1WiJ9\"" +
+			",\"Header\":{},\"Signature\":\"YjGj\"}"))
+		if _, err := env.getSignerInfo(); !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected MalformedSignatureError but found %q", reflect.TypeOf(err))
+		}
+	})
+
+	t.Run("with malformed cty header returns error", func(t *testing.T) {
+		env, _ := newJWSEnvelopeFromBytes([]byte("{\"Payload\":\"eyJhbGciOiJIUzI1NiJ9\",\"Protected\":\"eyJhbGciOiJQUzUxMiIsImN0eSI6MTIzLCJjcml0IjpbImlvLmNuY2Yubm90YXJ5LnNpZ25pbmdUaW1lIl0sImlvLmNuY2Yubm90YXJ5LnNpbmluZ1RpbWUiOiIyMDA2LTAxLTAyVDE1OjA0OjA1WiJ9\"" +
+			",\"Header\":{},\"Signature\":\"YjGj\"}"))
+		if _, err := env.getSignerInfo(); !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected MalformedSignatureError but found %q", reflect.TypeOf(err))
+		}
+	})
+}
+
+// Tests various scenarios around signPayload method
+func TestSignPayload(t *testing.T) {
+	env := jwsEnvelope{}
+	t.Run("using rsa key with newJWSEnvelope works", func(t *testing.T) {
+		req := getSignRequest()
+		_, err := env.signPayload(req)
+		if err != nil {
+			t.Errorf("getSignerInfo(). Error = %s", err)
+		}
+	})
+
+	t.Run("using ec key  with newJWSEnvelope works", func(t *testing.T) {
+		req := getSignRequest()
+		req.CertificateChain = []*x509.Certificate{testhelper.GetECLeafCertificate().Cert, testhelper.GetECRootCertificate().Cert}
+		_, err := env.signPayload(req)
+		if err != nil {
+			t.Errorf("getSignerInfo(). Error = %s", err)
+		}
+	})
+
+	t.Run("with unsupported certificate returns error", func(t *testing.T) {
+		req := getSignRequest()
+		req.CertificateChain = []*x509.Certificate{testhelper.GetUnsupportedCertificate().Cert}
+		if _, err := env.signPayload(req); !(err != nil && errors.As(err, new(UnsupportedSigningKeyError))) {
+			t.Errorf("Expected UnsupportedSigningKeyError but found %q", err)
+		}
+	})
+}

--- a/signer/jwt.go
+++ b/signer/jwt.go
@@ -1,0 +1,105 @@
+package signer
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// signJWT signs the given payload and headers using the given signing method and signature provider
+func signJWT(payload, headers map[string]interface{}, method jwt.SigningMethod, sigPro SignatureProvider) (string, error) {
+	var claims jwt.MapClaims = payload
+	token := &jwt.Token{
+		Header: headers,
+		Claims: claims,
+	}
+
+	token.Method = signingMethodForSign{algo: method.Alg(), sigProvider: sigPro}
+
+	// We are using custom signing method called `signingMethodForSign` which already has signature provider
+	// thus we don't need to pass signing key as input.
+	return token.SignedString(nil)
+}
+
+// verifyJWT verifies the JWT token against the specified verification key
+func verifyJWT(tokenString string, key crypto.PublicKey) error {
+	signingMethod, err := getSigningMethod(key)
+	if err != nil {
+		return err
+	}
+
+	// parse and verify token
+	parser := &jwt.Parser{
+		ValidMethods:         []string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"},
+		UseJSONNumber:        true,
+		SkipClaimsValidation: true,
+	}
+
+	if _, err := parser.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != signingMethod.Alg() {
+			return nil, MalformedSignatureError{msg: fmt.Sprintf("unexpected signing method: %v: require %v", t.Method.Alg(), signingMethod.Alg())}
+		}
+
+		// override default signing method with key-specific method
+		t.Method = signingMethod
+		return key, nil
+	}); err != nil {
+		return SignatureIntegrityError{err: err}
+	}
+	return nil
+}
+
+// signingMethodForSign is only used during signature generation operation. It's required by JWT library we are using
+type signingMethodForSign struct {
+	algo        string
+	sigProvider SignatureProvider
+}
+
+func (s signingMethodForSign) Verify(_, _ string, _ interface{}) error {
+	return UnsupportedOperationError{}
+}
+
+func (s signingMethodForSign) Sign(signingString string, _ interface{}) (string, error) {
+	seg, err := s.sigProvider.Sign([]byte(signingString))
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(seg), nil
+}
+
+func (s signingMethodForSign) Alg() string {
+	return s.algo
+}
+
+// getSigningMethod picks up a recommended algorithm for given public keys.
+func getSigningMethod(key crypto.PublicKey) (jwt.SigningMethod, error) {
+	switch key := key.(type) {
+	case *rsa.PublicKey:
+		switch key.Size() {
+		case 256:
+			return jwt.SigningMethodPS256, nil
+		case 384:
+			return jwt.SigningMethodPS384, nil
+		case 512:
+			return jwt.SigningMethodPS512, nil
+		default:
+			return nil, UnsupportedSigningKeyError{keyType: "rsa"}
+		}
+	case *ecdsa.PublicKey:
+		switch key.Curve.Params().BitSize {
+		case jwt.SigningMethodES256.CurveBits:
+			return jwt.SigningMethodES256, nil
+		case jwt.SigningMethodES384.CurveBits:
+			return jwt.SigningMethodES384, nil
+		case jwt.SigningMethodES512.CurveBits:
+			return jwt.SigningMethodES512, nil
+		default:
+			return nil, UnsupportedSigningKeyError{keyType: "ecdsa"}
+		}
+	}
+	return nil, UnsupportedSigningKeyError{}
+}

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -1,0 +1,455 @@
+package signer
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/notaryproject/notation-core-go/internal/testhelper"
+)
+
+const (
+	TestPayload  = "{\"targetArtifact\":{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"digest\":\"sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333\",\"size\":16724,\"annotations\":{\"io.wabbit-networks.buildId\":\"123\"}}}"
+	TestValidSig = "{\"payload\":\"eyJ0YXJnZXRBcnRpZmFjdCI6eyJhbm5vdGF0aW9ucyI6eyJpby53YWJiaXQtbmV0d29ya3MuYnVpbGRJZCI6IjEyMyJ9LCJkaWdlc3QiOiJzaGEyNTY6NzNjODAzOTMwZWEzYmExZTU0YmMyNWMyYmRjNTNlZGQwMjg0YzYyZWQ2NTFmZTdiMDAzNjlkYTUxOWEzYzMzMyIsIm1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UubWFuaWZlc3QudjEranNvbiIsInNpemUiOjE2NzI0fX0\"," +
+		"\"protected\":\"eyJhbGciOiJQUzM4NCIsImNyaXQiOlsiaW8uY25jZi5ub3RhcnkuZXhwaXJ5Iiwic2lnbmVkQ3JpdEtleTEiXSwiY3R5IjoiYXBwbGljYXRpb24vdm5kLmNuY2Yubm90YXJ5LnYyLmp3cy52MSIsImlvLmNuY2Yubm90YXJ5LmV4cGlyeSI6IjIwMjItMDYtMjVUMTA6NTY6MjItMDc6MDAiLCJpby5jbmNmLm5vdGFyeS5zaWduaW5nVGltZSI6IjIwMjItMDYtMjRUMTA6NTY6MjItMDc6MDAiLCJzaWduZWRDcml0S2V5MSI6InNpZ25lZFZhbHVlMSIsInNpZ25lZEtleTEiOiJzaWduZWRLZXkyIn0\"," +
+		"\"header\":{" +
+		"	\"x5c\":[" +
+		"		\"MIIEfDCCAuSgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBaMQswCQYDVQQGEwJVUzELMAkGA1UECBMCV0ExEDAOBgNVBAcTB1NlYXR0bGUxDzANBgNVBAoTBk5vdGFyeTEbMBkGA1UEAxMSTm90YXRpb24gVGVzdCBSb290MB4XDTIyMDYyNDE3NTYyMloXDTIyMDYyNTE3NTYyMlowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZOb3RhcnkxIDAeBgNVBAMTF05vdGF0aW9uIFRlc3QgTGVhZiBDZXJ0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAoXrZa9kJb3wbW2UthGcz382LBKDca3+vp5dv/3EOSZIvlofUWrtoIUcBOZLUfG+IBJvCZaxBrmLEYG0j/82BUB6s2abqQKKG3IN+/sfFa71zyQgsQwFjRn+9xjTqPYw+AU58JbGVy2i08/zBaGnEBMfR5ZN5AKTi9U3r5ImyldPK1BsBfH6PKs7tUwNsquIl2x4RdTTNl8husOFHLs+IFxJvNdTTG+SF5LSMLE6YUSJQGBd73vD+i5t7REQCs60TAGdZEjXHy83s+GHfNZ7QqB/4Ic9+cm0KibV8porDxZ08cuVJpyCxS9Y1UqewENC2Bv+THXUsrpEwI24+/zDX9qWDmXovVKXlWKJNyC6lfpyaHbLy16MahN5DNzgzAKEg1nNrwj310sodwjOAlBEGzzVVtarRasmJxyK8zTMEMWNU/wfivEmshwDmDP5d69ahpwv2pxxite/mCIdq2NWrtPyEgt93LdZMg3sBok3xrEPVzSMTdvz7DEYJ42jpC7bfAgMBAAGjSDBGMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAfBgNVHSMEGDAWgBSKBGCoAu++5bIcPlTOR480pJtNezANBgkqhkiG9w0BAQsFAAOCAYEAhadLSl5E6tKSztFeDQPsLoAMs1xXbnfevZcUVEhjS7U1XJjDdgCHRWUKKUo6J7zPYj9t6S0V93ClDI5mdtxZlx2SKhE973E5euVUrppV+AbAn9z6GiJiR3gMeuRc4RjbiFiPR2b4qz1t9uQWcjfq/zSPxsvwB8JqKVgHZyFhtyh0CRc0W3NxOvBBR9fKBv7GQArg9KGmG6TbUPoy+4Twl+UZhx8tkHBYAH0P+BroyKuERF8CFdrrQE2MiGi7ZORQvCLQEt93hH4SRyBQI+PWiTPg6bxoCiVJh4jReSwsvBMczu/x/Hpx6n+QocZXr2e2snHav9IC8X0+3U3FAVhAL4iasqimwoN2I1HUNESF1gQJBGOMesq7CpAMG3dfk0S3tWx3kTKib43LsP85Vxddw9PL74+q0iOvnYXEnA5j0EHe9Uu4LpPKewns7IPxBin1jZxkE3BXPGTH/g7D5BjhkAYnGCf0ynGX9wwOMipHJ1HkdVAQmwOqWXs9sqItEE7b\"," +
+		"		\"MIIEiTCCAvGgAwIBAgIBATANBgkqhkiG9w0BAQsFADBaMQswCQYDVQQGEwJVUzELMAkGA1UECBMCV0ExEDAOBgNVBAcTB1NlYXR0bGUxDzANBgNVBAoTBk5vdGFyeTEbMBkGA1UEAxMSTm90YXRpb24gVGVzdCBSb290MB4XDTIyMDYyNDE3NTYyMVoXDTIyMDcyNDE3NTYyMVowWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZOb3RhcnkxGzAZBgNVBAMTEk5vdGF0aW9uIFRlc3QgUm9vdDCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAK+1W8JztxWYge6R8QFJCOJuJ0al9etIdakrDSm87Cf14L1zCbkOPWOA0+L+1QLXwviYJ5NpcdTtNLczLJtgigCdZMxfK3ZODu47sT+9EJut85hguyUSvcHiwhKr8Qa7kLi7sE4svgje/L3paPuQr14TgMb1Tun3XAy5OnvGjMGKi1/zkJ6BCgXya/8L/oyaKgChEPDjY/xjWKTF+2Pzeq9ZLiHqNBjRHBqVUvYNtlPtb5SJm66r/IUtdNd8BA4gLEwIqVEruCN1895heybqcYR7vxomJ4/otLeb35En36+6MdOquDg/tuBciS1sXO/j6ZHpGDYGx3uqTIz7aNkRYvbejR/fq4mpaxLbRkNazg1PFIFmekOKJxQWRY7ap8c9XS6ABpOHQISh5vsev93LeEltnzOYUHNvKWJuz2YwA/hsPP8LaQVZRDL3iNtaTeL7rjSvNSLNyjI9LKyoNEAQ/PZBBhFIv/actIyY1pXyHvNzt11Mmf9JJ2BQz00mAaUfxwIDAQABo1owWDAOBgNVHQ8BAf8EBAMCAgQwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUigRgqALvvuWyHD5UzkePNKSbTXswDQYJKoZIhvcNAQELBQADggGBAGLiCmT97QfoYYuPJUZZXsLxFlJ71FmxRzUZ5c8dfAbFio/dEa54Ywzj8h+D9UYxsIcsAEHPZJHVsNJieYfHoOnGgVLBQrRcfayy+MhZQRAm7lB0U/e1H9XNtolX9USa/9N7MiLYlHhJU9dK6IFM8KItiC9IJ0aK4dRjFFb7RHMRoMeGXjZbFY0XfdvNlpT+PtrCU51BLEwD2MZfcSszxJpBK1+3nbVkIJ3jH55uwgsDDJMx9+fHCSaXPYCJo1/RAwWNrkrx88XSGFnr9PakJkzJaJKQinR603xQct27TBnIqnLq4dzibvJmRAf+PI/h0tplzE+vDJzPjz75hYj3QobC2tS81My6Ql0Urs3GZjIIX3ToBmsLyxz4QKDifdi9uenoadZiUwiX1ooFhtXHFOFIE5ZvrOPfEEsAiU4Hkvmukol688f7LfLHj2fABUurNcxTCSiI3pSKtl0vj3Px0a2R0ubVO+LJTpf7uHw1XFesYnCiPrS2r4y94I5S1ldxaA==\"]," +
+		"		\"io.cncf.notary.SigningAgent\":\"NotationUnitTest/1.0.0\"}," +
+		"\"signature\":\"J9iQDfXM1GYzIazRH36DUgjeBSp1YIv5gqb0evyrp46mRNdsvGxzBvqVM3K1ZYW530wryweL51oVTbXMEh2PWchQZ7g33Be5lgcl82il7rR5D5tpsiSZ7oZsD4LP-Swv6MoYlKW4hKXWTCY9cWLzJhHkGZPiLsyrWUqdBq_0M8BTyx42_MUmAbYrFVKRjZy8PKsFDAaBcZVbdyZWRqVJy4Lfw8n4P0Ry7bDWRkqhI2rXH4o68eSkNF3KGWzQWXTp6uZb7o5HKc3dn3uoNidKvP3kZaM-XfM9Hd9Cw1MxLwvu1Qdjo6MCOatMKxc02cI7LAA6AsRcYfR-vGkVW3bJP9L29GJ-Dufv7dWcC_xCEG7p6lSYcF86haY_iTwSv_IQoKXQrMnwL8yZpbshJBrdjOzojdZBsJ4_Pu7KdNsnTpR-UvnFdIUrPvYek5WwI8jLz9hTVsSzF0aWCnCf7t8sAaUf90CC04kwGP2jnvZKlNcTQpZ56Zl-n43Z6KkC62do\"}\n"
+)
+
+var (
+	TestTamperedSig = strings.Replace(TestValidSig, "0fX0", "1fX0=", 1)
+)
+
+func TestNewSignatureEnvelopeFromBytesError(t *testing.T) {
+	_, err := NewSignatureEnvelopeFromBytes([]byte("Malformed"), MediaTypeJWSJson)
+	if !(err != nil && errors.As(err, new(MalformedArgumentError))) {
+		t.Errorf("Expected MalformedArgumentError but found %q", reflect.TypeOf(err))
+	}
+}
+
+// Tests various scenarios around generating a signature envelope
+func TestSign(t *testing.T) {
+	env, err := NewSignatureEnvelope(MediaTypeJWSJson)
+	if err != nil {
+		t.Fatalf("NewSignatureEnvelope() error = %v", err)
+	}
+
+	t.Run("when all arguments are present", func(t *testing.T) {
+		req := getSignRequest()
+		verifySignWithRequest(env, req, t)
+	})
+
+	t.Run("when expiry is not present", func(t *testing.T) {
+		req := getSignRequest()
+		req.Expiry = time.Time{}
+		verifySignWithRequest(env, req, t)
+	})
+
+	t.Run("when signing agent is not present", func(t *testing.T) {
+		req := getSignRequest()
+		req.SigningAgent = ""
+		verifySignWithRequest(env, req, t)
+	})
+
+	t.Run("when extended attributes are not present", func(t *testing.T) {
+		req := getSignRequest()
+		req.ExtendedSignedAttrs = nil
+		verifySignWithRequest(env, req, t)
+	})
+}
+
+// Tests various error scenarios around generating a signature envelope
+func TestSignErrors(t *testing.T) {
+	env, _ := NewSignatureEnvelope(MediaTypeJWSJson)
+	req := getSignRequest()
+
+	t.Run("when Payload is absent", func(t *testing.T) {
+		req.Payload = nil
+		verifySignErrorWithRequest(env, req, t)
+	})
+
+	t.Run("when PayloadContentType is absent", func(t *testing.T) {
+		req = getSignRequest()
+		req.PayloadContentType = ""
+		verifySignErrorWithRequest(env, req, t)
+	})
+
+	t.Run("when SigningTime is absent", func(t *testing.T) {
+		req = getSignRequest()
+		req.SigningTime = time.Time{}
+		verifySignErrorWithRequest(env, req, t)
+	})
+
+	t.Run("when SignatureProvider is absent", func(t *testing.T) {
+		req = getSignRequest()
+		req.SignatureProvider = nil
+		verifySignErrorWithRequest(env, req, t)
+	})
+
+	t.Run("when CertificateChain is absent", func(t *testing.T) {
+		req = getSignRequest()
+		req.CertificateChain = nil
+		verifySignErrorWithRequest(env, req, t)
+	})
+
+	t.Run("when expiry is before singing time", func(t *testing.T) {
+		req = getSignRequest()
+		req.Expiry = req.SigningTime.AddDate(0, 0, -1)
+		verifySignErrorWithRequest(env, req, t)
+	})
+}
+
+// Tests various scenarios around signature envelope verification
+func TestVerify(t *testing.T) {
+	certs := "MIIEfDCCAuSgAwIBAgIBAjANBgkqhkiG9w0BAQsFADBaMQswCQYDVQQGEwJVUzELMAkGA1UECBMCV0ExEDAOBgNVBAcTB1NlYXR0bGUxDzANBgNVBAoTBk5vdGFyeTEbMBkGA1UEAxMSTm90YXRpb24gVGVzdCBSb290MB4XDTIyMDYyNDE3NTYyMloXDTIyMDYyNTE3NTYyMlowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZOb3RhcnkxIDAeBgNVBAMTF05vdGF0aW9uIFRlc3QgTGVhZiBDZXJ0MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAoXrZa9kJb3wbW2UthGcz382LBKDca3+vp5dv/3EOSZIvlofUWrtoIUcBOZLUfG+IBJvCZaxBrmLEYG0j/82BUB6s2abqQKKG3IN+/sfFa71zyQgsQwFjRn+9xjTqPYw+AU58JbGVy2i08/zBaGnEBMfR5ZN5AKTi9U3r5ImyldPK1BsBfH6PKs7tUwNsquIl2x4RdTTNl8husOFHLs+IFxJvNdTTG+SF5LSMLE6YUSJQGBd73vD+i5t7REQCs60TAGdZEjXHy83s+GHfNZ7QqB/4Ic9+cm0KibV8porDxZ08cuVJpyCxS9Y1UqewENC2Bv+THXUsrpEwI24+/zDX9qWDmXovVKXlWKJNyC6lfpyaHbLy16MahN5DNzgzAKEg1nNrwj310sodwjOAlBEGzzVVtarRasmJxyK8zTMEMWNU/wfivEmshwDmDP5d69ahpwv2pxxite/mCIdq2NWrtPyEgt93LdZMg3sBok3xrEPVzSMTdvz7DEYJ42jpC7bfAgMBAAGjSDBGMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAfBgNVHSMEGDAWgBSKBGCoAu++5bIcPlTOR480pJtNezANBgkqhkiG9w0BAQsFAAOCAYEAhadLSl5E6tKSztFeDQPsLoAMs1xXbnfevZcUVEhjS7U1XJjDdgCHRWUKKUo6J7zPYj9t6S0V93ClDI5mdtxZlx2SKhE973E5euVUrppV+AbAn9z6GiJiR3gMeuRc4RjbiFiPR2b4qz1t9uQWcjfq/zSPxsvwB8JqKVgHZyFhtyh0CRc0W3NxOvBBR9fKBv7GQArg9KGmG6TbUPoy+4Twl+UZhx8tkHBYAH0P+BroyKuERF8CFdrrQE2MiGi7ZORQvCLQEt93hH4SRyBQI+PWiTPg6bxoCiVJh4jReSwsvBMczu/x/Hpx6n+QocZXr2e2snHav9IC8X0+3U3FAVhAL4iasqimwoN2I1HUNESF1gQJBGOMesq7CpAMG3dfk0S3tWx3kTKib43LsP85Vxddw9PL74+q0iOvnYXEnA5j0EHe9Uu4LpPKewns7IPxBin1jZxkE3BXPGTH/g7D5BjhkAYnGCf0ynGX9wwOMipHJ1HkdVAQmwOqWXs9sqItEE7b," +
+		"MIIEiTCCAvGgAwIBAgIBATANBgkqhkiG9w0BAQsFADBaMQswCQYDVQQGEwJVUzELMAkGA1UECBMCV0ExEDAOBgNVBAcTB1NlYXR0bGUxDzANBgNVBAoTBk5vdGFyeTEbMBkGA1UEAxMSTm90YXRpb24gVGVzdCBSb290MB4XDTIyMDYyNDE3NTYyMVoXDTIyMDcyNDE3NTYyMVowWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZOb3RhcnkxGzAZBgNVBAMTEk5vdGF0aW9uIFRlc3QgUm9vdDCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAK+1W8JztxWYge6R8QFJCOJuJ0al9etIdakrDSm87Cf14L1zCbkOPWOA0+L+1QLXwviYJ5NpcdTtNLczLJtgigCdZMxfK3ZODu47sT+9EJut85hguyUSvcHiwhKr8Qa7kLi7sE4svgje/L3paPuQr14TgMb1Tun3XAy5OnvGjMGKi1/zkJ6BCgXya/8L/oyaKgChEPDjY/xjWKTF+2Pzeq9ZLiHqNBjRHBqVUvYNtlPtb5SJm66r/IUtdNd8BA4gLEwIqVEruCN1895heybqcYR7vxomJ4/otLeb35En36+6MdOquDg/tuBciS1sXO/j6ZHpGDYGx3uqTIz7aNkRYvbejR/fq4mpaxLbRkNazg1PFIFmekOKJxQWRY7ap8c9XS6ABpOHQISh5vsev93LeEltnzOYUHNvKWJuz2YwA/hsPP8LaQVZRDL3iNtaTeL7rjSvNSLNyjI9LKyoNEAQ/PZBBhFIv/actIyY1pXyHvNzt11Mmf9JJ2BQz00mAaUfxwIDAQABo1owWDAOBgNVHQ8BAf8EBAMCAgQwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUigRgqALvvuWyHD5UzkePNKSbTXswDQYJKoZIhvcNAQELBQADggGBAGLiCmT97QfoYYuPJUZZXsLxFlJ71FmxRzUZ5c8dfAbFio/dEa54Ywzj8h+D9UYxsIcsAEHPZJHVsNJieYfHoOnGgVLBQrRcfayy+MhZQRAm7lB0U/e1H9XNtolX9USa/9N7MiLYlHhJU9dK6IFM8KItiC9IJ0aK4dRjFFb7RHMRoMeGXjZbFY0XfdvNlpT+PtrCU51BLEwD2MZfcSszxJpBK1+3nbVkIJ3jH55uwgsDDJMx9+fHCSaXPYCJo1/RAwWNrkrx88XSGFnr9PakJkzJaJKQinR603xQct27TBnIqnLq4dzibvJmRAf+PI/h0tplzE+vDJzPjz75hYj3QobC2tS81My6Ql0Urs3GZjIIX3ToBmsLyxz4QKDifdi9uenoadZiUwiX1ooFhtXHFOFIE5ZvrOPfEEsAiU4Hkvmukol688f7LfLHj2fABUurNcxTCSiI3pSKtl0vj3Px0a2R0ubVO+LJTpf7uHw1XFesYnCiPrS2r4y94I5S1ldxaA=="
+	var trustedCertsBytes []byte
+	for _, element := range strings.Split(certs, ",") {
+		certBytes, _ := base64.StdEncoding.DecodeString(element)
+		trustedCertsBytes = append(trustedCertsBytes, certBytes...)
+	}
+	trustedCerts, _ := x509.ParseCertificates(trustedCertsBytes)
+
+	env, err := NewSignatureEnvelopeFromBytes([]byte(TestValidSig), MediaTypeJWSJson)
+	if err != nil {
+		t.Fatalf("NewSignatureEnvelopeFromBytes() error = %v", err)
+	}
+
+	vSignInfo, err := env.Verify()
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+
+	info, err := env.GetSignerInfo()
+	if err != nil {
+		t.Fatalf("GetSignerInfo() error = %v", err)
+	}
+
+	req := getSignRequest()
+	req.SigningTime, err = time.Parse(time.RFC3339, "2022-06-24T10:56:22-07:00")
+	req.Expiry = req.SigningTime.AddDate(0, 0, 1)
+	req.CertificateChain = []*x509.Certificate{trustedCerts[0], trustedCerts[1]}
+	verifySignerInfo(info, req, t)
+
+	if !areSignInfoEqual(vSignInfo, info) {
+		t.Fatalf("SignerInfo object returned by Verify() and GetSignerInfo() are different.\n"+
+			"Verify=%+v \nGetSignerInfo=%+v", vSignInfo, info)
+	}
+}
+
+// Tests various error scenarios around signature envelope verification
+func TestVerifyErrors(t *testing.T) {
+	t.Run("when tempered signature envelope is provided", func(t *testing.T) {
+		env, _ := NewSignatureEnvelopeFromBytes([]byte(TestTamperedSig), MediaTypeJWSJson)
+		_, err := env.Verify()
+		if !(err != nil && errors.As(err, new(SignatureIntegrityError))) {
+			t.Errorf("Expected SignatureIntegrityError but found %T", err)
+		}
+	})
+
+	t.Run("when malformed signature envelope is provided", func(t *testing.T) {
+		env, _ := NewSignatureEnvelopeFromBytes([]byte("{}"), MediaTypeJWSJson)
+		_, err := env.Verify()
+		if !(err != nil && errors.As(err, new(MalformedSignatureError))) {
+			t.Errorf("Expected SignatureIntegrityError but found %T", err)
+		}
+	})
+}
+
+// Tests various scenarios around sign first and then verify envelope verification
+func TestSignAndVerify(t *testing.T) {
+	t.Run("with RSA certificate", func(t *testing.T) {
+		// Sign
+		env, err := NewSignatureEnvelope(MediaTypeJWSJson)
+		if err != nil {
+			t.Fatalf("NewSignatureEnvelope() error = %v", err)
+		}
+
+		req := getSignRequest()
+		sig, err := env.Sign(req)
+		if err != nil || len(sig) == 0 {
+			t.Fatalf("Sign() error = %v", err)
+		}
+
+		// Verify using same env struct
+		_, err = env.Verify()
+		if err != nil {
+			t.Fatalf("Verify() error = %v", err)
+		}
+
+		info, err := env.GetSignerInfo()
+		if err != nil {
+			t.Fatalf("GetSignerInfo() error = %v", err)
+		}
+
+		verifySignerInfo(info, req, t)
+	})
+
+	t.Run("with EC certificate", func(t *testing.T) {
+		// Sign
+		env, err := NewSignatureEnvelope(MediaTypeJWSJson)
+		if err != nil {
+			t.Fatalf("NewSignatureEnvelope() error = %v", err)
+		}
+
+		req := getSignRequest()
+		req.CertificateChain = []*x509.Certificate{testhelper.GetECLeafCertificate().Cert, testhelper.GetECRootCertificate().Cert}
+		req.SignatureProvider = MySigner{ecdsaKey: testhelper.GetECLeafCertificate().PrivateKey}
+		sig, err := env.Sign(req)
+		if err != nil || len(sig) == 0 {
+			t.Fatalf("Sign() error = %v", err)
+		}
+
+		// Verify using same env struct
+		_, err = env.Verify()
+		if err != nil {
+			t.Fatalf("Verify() error = %v", err)
+		}
+
+		info, err := env.GetSignerInfo()
+		if err != nil {
+			t.Fatalf("GetSignerInfo() error = %v", err)
+		}
+
+		verifySignerInfo(info, req, t)
+	})
+}
+
+// Tests various error scenarios around GetSignerInfo method
+func TestGetSignerInfoErrors(t *testing.T) {
+	env, _ := NewSignatureEnvelope(MediaTypeJWSJson)
+	t.Run("when called GetSignerInfo before sign or verify.", func(t *testing.T) {
+		_, err := env.GetSignerInfo()
+		if !(err != nil && errors.As(err, new(SignatureNotFoundError))) {
+			t.Errorf("Expected SignatureNotFoundError but found %q", err)
+		}
+	})
+
+	t.Run("when called GetSignerInfo after failed sign or verify call.", func(t *testing.T) {
+		req := getSignRequest()
+		req.Payload = []byte("Sad")
+		env.Sign(req)
+		env.Verify()
+		_, err := env.GetSignerInfo()
+		if !(err != nil && errors.As(err, new(SignatureNotFoundError))) {
+			t.Errorf("Expected SignatureNotFoundError but but found %q", reflect.TypeOf(err))
+		}
+	})
+}
+
+func TestVerifyAuthenticity(t *testing.T) {
+	env, _ := NewSignatureEnvelope(MediaTypeJWSJson)
+	req := getSignRequest()
+	env.Sign(req)
+	info, _ := env.GetSignerInfo()
+
+	t.Run("when trustedCerts is root cert", func(t *testing.T) {
+		root := req.CertificateChain[len(req.CertificateChain)-1]
+		trust, err := VerifyAuthenticity(info, []*x509.Certificate{root, testhelper.GetECRootCertificate().Cert})
+		if err != nil {
+			t.Fatalf("VerifyAuthenticity() error = %v", err)
+		}
+
+		if !trust.Equal(root) {
+			t.Fatalf("Expected cert with subject %q but found cert with subject %q",
+				root.Subject, trust.Subject)
+		}
+	})
+
+	t.Run("when trustedCerts is leaf cert", func(t *testing.T) {
+		leaf := req.CertificateChain[0]
+		trust, err := VerifyAuthenticity(info, []*x509.Certificate{leaf, testhelper.GetECRootCertificate().Cert})
+		if err != nil {
+			t.Fatalf("VerifyAuthenticity() error = %v", err)
+		}
+
+		if !trust.Equal(leaf) {
+			t.Fatalf("Expected cert with subject %q but found cert with subject %q",
+				leaf.Subject, trust.Subject)
+		}
+	})
+}
+
+func TestVerifyAuthenticityError(t *testing.T) {
+	env, _ := NewSignatureEnvelope(MediaTypeJWSJson)
+	req := getSignRequest()
+	env.Sign(req)
+	info, _ := env.GetSignerInfo()
+
+	t.Run("when trustedCerts are not trusted", func(t *testing.T) {
+		_, err := VerifyAuthenticity(info, []*x509.Certificate{testhelper.GetECRootCertificate().Cert})
+		if !(err != nil && errors.As(err, new(SignatureAuthenticityError))) {
+			t.Errorf("Expected SignatureAuthenticityError but found %T", err)
+		}
+	})
+
+	t.Run("when trustedCerts is absent", func(t *testing.T) {
+		_, err := VerifyAuthenticity(info, []*x509.Certificate{})
+		if !(err != nil && errors.As(err, new(MalformedArgumentError))) {
+			t.Errorf("Expected MalformedArgumentError but found %T", err)
+		}
+	})
+
+	t.Run("when trustedCerts array is of zero length", func(t *testing.T) {
+		_, err := VerifyAuthenticity(info, nil)
+		if !(err != nil && errors.As(err, new(MalformedArgumentError))) {
+			t.Errorf("Expected MalformedArgumentError but found %T", err)
+		}
+	})
+
+	t.Run("when SignerInfo is absent", func(t *testing.T) {
+		_, err := VerifyAuthenticity(nil, []*x509.Certificate{testhelper.GetECRootCertificate().Cert})
+		if !(err != nil && errors.As(err, new(MalformedArgumentError))) {
+			t.Errorf("Expected MalformedArgumentError but found %T", err)
+		}
+	})
+
+	t.Run("when cert chain in signer info is absent", func(t *testing.T) {
+		signInfoCopy := *info
+		signInfoCopy.CertificateChain = nil
+		_, err := VerifyAuthenticity(&signInfoCopy, nil)
+		if !(err != nil && errors.As(err, new(MalformedArgumentError))) {
+			t.Errorf("Expected MalformedArgumentError but found %T", err)
+		}
+	})
+
+}
+
+type MySigner struct {
+	rsaKey   *rsa.PrivateKey
+	ecdsaKey *ecdsa.PrivateKey
+}
+
+func (m MySigner) Sign(bytes []byte) ([]byte, error) {
+	hasher := crypto.SHA384.New()
+	hasher.Write(bytes)
+	if m.ecdsaKey == nil {
+		// Sign the string and return the encoded bytes
+		return rsa.SignPSS(rand.Reader, m.rsaKey, crypto.SHA384, hasher.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+	}
+
+	// Sign the string and return r, s
+	r, s, _ := ecdsa.Sign(rand.Reader, m.ecdsaKey, hasher.Sum(nil))
+	curveBits := m.ecdsaKey.Curve.Params().BitSize
+
+	keyBytes := curveBits / 8
+	if curveBits%8 > 0 {
+		keyBytes += 1
+	}
+	out := make([]byte, 2*keyBytes)
+	r.FillBytes(out[0:keyBytes]) // r is assigned to the first half of output.
+	s.FillBytes(out[keyBytes:])  // s is assigned to the second half of output.
+	return out, nil
+}
+
+func getSignRequest() SignRequest {
+	return SignRequest{
+		Payload:            []byte(TestPayload),
+		PayloadContentType: PayloadContentTypeJWSV1,
+		CertificateChain:   []*x509.Certificate{testhelper.GetRSALeafCertificate().Cert, testhelper.GetRSARootCertificate().Cert},
+		SigningTime:        time.Now(),
+		Expiry:             time.Now().AddDate(0, 0, 1),
+		ExtendedSignedAttrs: []Attribute{
+			{Key: "signedCritKey1", Value: "signedValue1", Critical: true},
+			{Key: "signedKey1", Value: "signedKey2", Critical: false}},
+		SigningAgent:      "NotationUnitTest/1.0.0",
+		SignatureProvider: MySigner{rsaKey: testhelper.GetRSALeafCertificate().PrivateKey},
+	}
+}
+
+func verifySignerInfo(signInfo *SignerInfo, request SignRequest, t *testing.T) {
+	if request.SigningAgent != signInfo.UnsignedAttributes.SigningAgent {
+		t.Errorf("SigningAgent: expected value %q but found %q", request.SigningAgent, signInfo.UnsignedAttributes.SigningAgent)
+	}
+
+	if !reflect.DeepEqual(request.CertificateChain, signInfo.CertificateChain) {
+		t.Errorf("Mistmatch between expected and actual CertificateChain")
+	}
+
+	if request.SigningTime.Format(time.RFC3339) != signInfo.SignedAttributes.SigningTime.Format(time.RFC3339) {
+		t.Errorf("SigningTime: expected value %q but found %q", request.SigningTime, signInfo.SignedAttributes.SigningTime)
+	}
+
+	if request.Expiry.Format(time.RFC3339) != signInfo.SignedAttributes.Expiry.Format(time.RFC3339) {
+		t.Errorf("Expiry: expected value %q but found %q", request.SigningTime, signInfo.SignedAttributes.Expiry)
+	}
+
+	if !areAttrEqual(request.ExtendedSignedAttrs, signInfo.SignedAttributes.ExtendedAttributes) {
+		if !(len(request.ExtendedSignedAttrs) == 0 && len(signInfo.SignedAttributes.ExtendedAttributes) == 0) {
+			t.Errorf("Mistmatch between expected and actual ExtendedAttributes")
+		}
+	}
+
+	if request.PayloadContentType != signInfo.PayloadContentType {
+		t.Errorf("PayloadContentType: expected value %q but found %q", request.PayloadContentType, signInfo.PayloadContentType)
+	}
+
+	// The input payload and the payload signed are different because the jwt library we are using converts
+	// payload to map and then to json but the content of payload should be same
+	var requestPay map[string]interface{}
+	if err := json.Unmarshal(request.Payload, &requestPay); err != nil {
+		t.Log(err)
+	}
+
+	var signerInfoPay map[string]interface{}
+	if err := json.Unmarshal(signInfo.Payload, &signerInfoPay); err != nil {
+		t.Log(err)
+	}
+
+	if !reflect.DeepEqual(signerInfoPay, signerInfoPay) {
+		t.Errorf("Payload: expected value %q but found %q", requestPay, signerInfoPay)
+	}
+}
+
+func verifySignWithRequest(env *SignatureEnvelope, req SignRequest, t *testing.T) {
+	sig, err := env.Sign(req)
+	if err != nil || len(sig) == 0 {
+		t.Fatalf("Sign() error = %v", err)
+	}
+
+	info, err := env.GetSignerInfo()
+	if err != nil {
+		t.Fatalf("GetSignerInfo() error = %v", err)
+	}
+
+	verifySignerInfo(info, req, t)
+}
+
+func verifySignErrorWithRequest(env *SignatureEnvelope, req SignRequest, t *testing.T) {
+	_, err := env.Sign(req)
+	if !(err != nil && errors.As(err, new(MalformedSignRequestError))) {
+		t.Errorf("Expected MalformedArgumentError but but found %q", reflect.TypeOf(err))
+	}
+}
+
+func areAttrEqual(u []Attribute, v []Attribute) bool {
+	sort.Slice(u, func(p, q int) bool {
+		return u[p].Key < u[q].Key
+	})
+	sort.Slice(v, func(p, q int) bool {
+		return v[p].Key < v[q].Key
+	})
+	return reflect.DeepEqual(u, v)
+}
+
+func areSignInfoEqual(u *SignerInfo, v *SignerInfo) bool {
+	uExtAttr := u.SignedAttributes.ExtendedAttributes
+	vExtAttr := v.SignedAttributes.ExtendedAttributes
+	u.SignedAttributes.ExtendedAttributes = nil
+	v.SignedAttributes.ExtendedAttributes = nil
+	return reflect.DeepEqual(u, v) && areAttrEqual(uExtAttr, vExtAttr)
+}


### PR DESCRIPTION
Change Log:
- Implements SignatureEnvelope struct that would be used by notation-go-lib to generate/verify the signature.
- SignatureEnvelope internally implements actual signature formats like jws(cose in future)
- Implemented JWS-JSON signature generation and verification code.