### PR TITLE
fix hash function name according to the spec

### DIFF
--- a/signer/types.go
+++ b/signer/types.go
@@ -8,6 +8,9 @@ type SignatureMediaType string
 // SignatureAlgorithm lists supported signature algorithms.
 type SignatureAlgorithm string
 
+// HashAlgorithm algorithm associated with the key spec.
+type HashAlgorithm string
+
 // One of following supported specs
 // https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
 const (
@@ -19,18 +22,38 @@ const (
 	ECDSA_SHA_512      SignatureAlgorithm = "ECDSA_SHA_512"
 )
 
+// One of following supported specs
+// https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
+const (
+	SHA_256 HashAlgorithm = "SHA_256"
+	SHA_384 HashAlgorithm = "SHA_384"
+	SHA_512 HashAlgorithm = "SHA_512"
+)
+
+// HashFunc returns the Hash associated k.
+func (h HashAlgorithm) HashFunc() crypto.Hash {
+	switch h {
+	case SHA_256:
+		return crypto.SHA256
+	case SHA_384:
+		return crypto.SHA384
+	case SHA_512:
+		return crypto.SHA512
+	}
+	return 0
+}
+
 // Hash returns the Hash associated s.
-func (s SignatureAlgorithm) Hash() crypto.Hash {
-	var hash crypto.Hash
+func (s SignatureAlgorithm) Hash() HashAlgorithm {
 	switch s {
 	case RSASSA_PSS_SHA_256, ECDSA_SHA_256:
-		hash = crypto.SHA256
+		return SHA_256
 	case RSASSA_PSS_SHA_384, ECDSA_SHA_384:
-		hash = crypto.SHA384
+		return SHA_384
 	case RSASSA_PSS_SHA_512, ECDSA_SHA_512:
-		hash = crypto.SHA512
+		return SHA_512
 	}
-	return hash
+	return ""
 }
 
 // KeySpec defines a key type and size.

--- a/signer/utils.go
+++ b/signer/utils.go
@@ -60,12 +60,12 @@ func GetLocalSignatureProvider(certs []*x509.Certificate, pk crypto.PrivateKey) 
 type LocalSignatureProvider struct {
 	keySpec KeySpec
 	key     crypto.PrivateKey
-	certs  []*x509.Certificate
+	certs   []*x509.Certificate
 }
 
 func (l LocalSignatureProvider) Sign(bytes []byte) ([]byte, []*x509.Certificate, error) {
 	// calculate hash
-	hasher := l.keySpec.SignatureAlgorithm().Hash()
+	hasher := l.keySpec.SignatureAlgorithm().Hash().HashFunc()
 	h := hasher.New()
 	h.Write(bytes)
 	hash := h.Sum(nil)


### PR DESCRIPTION
Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>

This PR fixes https://github.com/notaryproject/notation/issues/268.
According to the [plugin spec](https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md), the `hashAlgorithm` field of `GenerateSignatureRequest` should be one of the following strings.
```
  // Hash algorithm associated with the key spec, plugin must 
  // hash the payload using this hash algorithm
  "hashAlgorithm" : "SHA_256" | "SHA_384" | "SHA_512",
```
However, the current implementation uses `crypto.Hash.String()`, which will return a string like `SHA-256` and break the azure-kv plugin.
Also need to update notation-go and notation to make the plugin works.