### PR TITLE
refactor: use internal envelope to verify

### DIFF
--- a/signature/internal/base/envelope.go
+++ b/signature/internal/base/envelope.go
@@ -37,17 +37,7 @@ func (e *Envelope) Verify() (*signature.Payload, *signature.SignerInfo, error) {
 		return nil, nil, &signature.MalformedSignatureError{}
 	}
 
-	payload, _, err := e.Envelope.Verify()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	signerInfo, err := e.SignerInfo()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return payload, signerInfo, nil
+	return e.Envelope.Verify()
 }
 
 // Payload returns the payload to be signed.


### PR DESCRIPTION
### What?

Refactor `Verify` so that it just returns the payload and signerInfo from the internal envelope.

Signed-off-by: Binbin Li <libinbin@microsoft.com>