### PR TITLE
fix: update envelope.Payload() logic

### DIFF
--- a/signature/jws/envelope_test.go
+++ b/signature/jws/envelope_test.go
@@ -89,7 +89,6 @@ func Test_envelope_Verify_failed(t *testing.T) {
 	if err != nil {
 		t.Fatal(t)
 	}
-
 	// manipulate envelope
 	encoded[len(encoded)-10] = 'C'
 

--- a/signature/jws/jws.go
+++ b/signature/jws/jws.go
@@ -176,10 +176,12 @@ func generateJWS(compact string, req *signature.SignRequest, certs []*x509.Certi
 	}, nil
 }
 
-func getSignedAttrs(req *signature.SignRequest, sigAlg signature.Algorithm) (map[string]interface{}, error) {
+// getSignerAttrs merge extended signed attributes and protected header to be signed attributes
+func getSignedAttrs(req *signature.SignRequest) (map[string]interface{}, error) {
 	extAttrs := make(map[string]interface{})
 	crit := []string{headerKeySigningScheme}
 
+	// write extended signed attributes to the extAttrs map
 	for _, elm := range req.ExtendedSignedAttributes {
 		extAttrs[elm.Key] = elm.Value
 		if elm.Critical {
@@ -187,13 +189,14 @@ func getSignedAttrs(req *signature.SignRequest, sigAlg signature.Algorithm) (map
 		}
 	}
 
-	alg, err := convertAlgorithm(sigAlg)
+	// extract JWT algorithm name from signer
+	jwtAlgorithm, err := extractJwtAlgorithm(req.Signer)
 	if err != nil {
 		return nil, err
 	}
 
 	jwsProtectedHeader := jwsProtectedHeader{
-		Algorithm:     alg,
+		Algorithm:     jwtAlgorithm,
 		ContentType:   req.Payload.ContentType,
 		SigningScheme: req.SigningScheme,
 	}

--- a/signature/jws/jwt.go
+++ b/signature/jws/jwt.go
@@ -14,8 +14,8 @@ type remoteSigningMethod struct {
 	signer signature.Signer
 }
 
-func newRemoteSigningMethod(signer signature.Signer) (jwt.SigningMethod, error) {
-	return &remoteSigningMethod{signer: signer}, nil
+func newRemoteSigningMethod(signer signature.Signer) jwt.SigningMethod {
+	return &remoteSigningMethod{signer: signer}
 }
 
 // Verify doesn't need to be implemented.
@@ -71,7 +71,7 @@ func verifyJWT(tokenString string, cert *x509.Certificate) error {
 	signingMethod := jwt.GetSigningMethod(jwsAlg)
 
 	parser := jwt.NewParser(
-		jwt.WithValidMethods([]string{"PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}),
+		jwt.WithValidMethods(validMethods),
 		jwt.WithJSONNumber(),
 		jwt.WithoutClaimsValidation(),
 	)

--- a/signature/jws/types.go
+++ b/signature/jws/types.go
@@ -3,6 +3,7 @@ package jws
 import (
 	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/notaryproject/notation-core-go/signature"
 )
 
@@ -80,13 +81,24 @@ type jwsEnvelope struct {
 	Signature string `json:"signature"`
 }
 
+var (
+	ps256 = jwt.SigningMethodPS256.Name
+	ps384 = jwt.SigningMethodPS384.Name
+	ps512 = jwt.SigningMethodPS512.Name
+	es256 = jwt.SigningMethodES256.Name
+	es384 = jwt.SigningMethodES384.Name
+	es512 = jwt.SigningMethodES512.Name
+)
+
+var validMethods = []string{ps256, ps384, ps512, es256, es384, es512}
+
 var signatureAlgJWSAlgMap = map[signature.Algorithm]string{
-	signature.AlgorithmPS256: "PS256",
-	signature.AlgorithmPS384: "PS384",
-	signature.AlgorithmPS512: "PS512",
-	signature.AlgorithmES256: "ES256",
-	signature.AlgorithmES384: "ES384",
-	signature.AlgorithmES512: "ES512",
+	signature.AlgorithmPS256: ps256,
+	signature.AlgorithmPS384: ps384,
+	signature.AlgorithmPS512: ps512,
+	signature.AlgorithmES256: es256,
+	signature.AlgorithmES384: es384,
+	signature.AlgorithmES512: es512,
 }
 
 var jwsAlgSignatureAlgMap = reverseMap(signatureAlgJWSAlgMap)


### PR DESCRIPTION
1. Payload() returns the raw payload context instead of base64 encoded data
2. move extract algorithm step from Sign() to getSignedAttrs()
3. wrap the parse error in a MalformedSignatureError