### PR TITLE
refactor: refactor signer and envelope to make Sign() return certs as…

### DIFF
--- a/signature/signer.go
+++ b/signature/signer.go
@@ -11,11 +11,8 @@ import (
 
 // Signer is used to sign bytes generated after signature envelope created.
 type Signer interface {
-	// Sign signs the digest and returns the raw signature.
-	Sign(digest []byte) ([]byte, error)
-
-	// CertificateChain returns the certificate chain.
-	CertificateChain() ([]*x509.Certificate, error)
+	// Sign signs the payload and returns the raw signature and certificates.
+	Sign(payload []byte) ([]byte, []*x509.Certificate, error)
 
 	// KeySpec returns the key specification.
 	KeySpec() (KeySpec, error)
@@ -24,6 +21,9 @@ type Signer interface {
 // LocalSigner is used by built-in signers to sign only.
 type LocalSigner interface {
 	Signer
+
+	// CertificateChain returns the certificate chain.
+	CertificateChain() ([]*x509.Certificate, error)
 
 	// PrivateKey returns the private key.
 	PrivateKey() crypto.PrivateKey
@@ -84,20 +84,20 @@ func isKeyPair(priv crypto.PrivateKey, pub crypto.PublicKey, keySpec KeySpec) bo
 	}
 }
 
-// Sign signs the digest and returns the raw signature.
+// Sign signs the digest and returns the raw signature and certificates.
 // This implementation should never be used by built-in signers.
-func (s *signer) Sign(digest []byte) ([]byte, error) {
-	return nil, fmt.Errorf("local signer doesn't support sign with digest")
-}
-
-// CertificateChain returns the certificate chain.
-func (s *signer) CertificateChain() ([]*x509.Certificate, error) {
-	return s.certs, nil
+func (s *signer) Sign(digest []byte) ([]byte, []*x509.Certificate, error) {
+	return nil, nil, fmt.Errorf("local signer doesn't support sign with digest")
 }
 
 // KeySpec returns the key specification.
 func (s *signer) KeySpec() (KeySpec, error) {
 	return s.keySpec, nil
+}
+
+// CertificateChain returns the certificate chain.
+func (s *signer) CertificateChain() ([]*x509.Certificate, error) {
+	return s.certs, nil
 }
 
 // PrivateKey returns the private key.

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -107,25 +107,15 @@ func TestNewLocalSigner(t *testing.T) {
 func TestSign(t *testing.T) {
 	signer := &signer{}
 
-	_, err := signer.Sign(make([]byte, 0))
+	raw, certs, err := signer.Sign(make([]byte, 0))
 	if err == nil {
 		t.Errorf("expect error but got nil")
 	}
-}
-
-func TestCertificateChain(t *testing.T) {
-	expectCerts := []*x509.Certificate{
-		testhelper.GetRSALeafCertificate().Cert,
+	if raw != nil {
+		t.Errorf("expect nil raw signature but got %v", raw)
 	}
-	signer := &signer{certs: expectCerts}
-
-	certs, err := signer.CertificateChain()
-
-	if err != nil {
-		t.Errorf("expect no error but got %v", err)
-	}
-	if !reflect.DeepEqual(certs, expectCerts) {
-		t.Errorf("expect certs %+v, got %+v", expectCerts, certs)
+	if certs != nil {
+		t.Errorf("expect nil certs but got %v", certs)
 	}
 }
 


### PR DESCRIPTION
### What?

1. Refactor Envelope and Signer interfaces to let Sign() api to return `certs` as well.
2. Remove `Certificates` api from Signer interface.
3. Update unit tests. 

Signed-off-by: Binbin Li <libinbin@microsoft.com>