### PR TITLE
fix: fix the certs validation in envelope.Sign()

### DIFF
--- a/signature/internal/base/envelope.go
+++ b/signature/internal/base/envelope.go
@@ -34,7 +34,16 @@ func (e *Envelope) Sign(req *signature.SignRequest) ([]byte, error) {
 	}
 
 	// validate certificate chain
-	if _, err := e.SignerInfo(); err != nil {
+	signerInfo, err := e.Envelope.SignerInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateCertificateChain(
+		signerInfo.CertificateChain,
+		signerInfo.SignedAttributes.SigningTime,
+		signerInfo.SignatureAlgorithm,
+	); err != nil {
 		return nil, err
 	}
 

--- a/signature/internal/base/envelope_test.go
+++ b/signature/internal/base/envelope_test.go
@@ -177,8 +177,18 @@ func TestSign(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "err returned by internal envelope",
+			name: "internal envelope fails to sign",
 			req:  signReq1,
+			env: &Envelope{
+				Raw:      nil,
+				Envelope: mockEnvelope{},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "internal envelope fails to get signerInfo",
+			req:  validReq,
 			env: &Envelope{
 				Raw:      nil,
 				Envelope: mockEnvelope{},
@@ -190,22 +200,24 @@ func TestSign(t *testing.T) {
 			name: "invalid certificate chain",
 			req:  validReq,
 			env: &Envelope{
-				Raw:      nil,
-				Envelope: mockEnvelope{},
+				Raw: nil,
+				Envelope: mockEnvelope{
+					signerInfo: &signature.SignerInfo{},
+				},
 			},
 			expect:    nil,
 			expectErr: true,
 		},
 		{
 			name: "successfully signed",
-			req: validReq,
+			req:  validReq,
 			env: &Envelope{
 				Raw: validBytes,
 				Envelope: &mockEnvelope{
 					signerInfo: validSignerInfo,
 				},
 			},
-			expect: validBytes,
+			expect:    validBytes,
 			expectErr: false,
 		},
 	}


### PR DESCRIPTION
### What?

Fix the workflow in envelope.Sign() so that we validate the certificate chain after signing correctly.

Signed-off-by: Binbin Li <libinbin@microsoft.com>