### PR TITLE
refactor: refactor SignatureProvider to Signer

### DIFF
--- a/signature/algorithm.go
+++ b/signature/algorithm.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -34,6 +35,19 @@ const (
 type KeySpec struct {
 	Type KeyType
 	Size int
+}
+
+// Hash returns the hash function of the algorithm.
+func (alg Algorithm) Hash() crypto.Hash {
+	switch alg {
+	case AlgorithmPS256, AlgorithmES256:
+		return crypto.SHA256
+	case AlgorithmPS384, AlgorithmES384:
+		return crypto.SHA384
+	case AlgorithmPS512, AlgorithmES512:
+		return crypto.SHA512
+	}
+	return 0
 }
 
 // ExtractKeySpec extracts KeySpec from the signing certificate.

--- a/signature/algorithm.go
+++ b/signature/algorithm.go
@@ -1,0 +1,70 @@
+package signature
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+)
+
+// Algorithm defines the signature algorithm.
+type Algorithm int
+
+// Signature algorithms supported by this library.
+//
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
+const (
+	AlgorithmPS256 Algorithm = 1 + iota // RSASSA-PSS with SHA-256
+	AlgorithmPS384                      // RSASSA-PSS with SHA-384
+	AlgorithmPS512                      // RSASSA-PSS with SHA-512
+	AlgorithmES256                      // ECDSA on secp256r1 with SHA-256
+	AlgorithmES384                      // ECDSA on secp384r1 with SHA-384
+	AlgorithmES512                      // ECDSA on secp521r1 with SHA-512
+)
+
+// KeyType defines the key type.
+type KeyType int
+
+const (
+	KeyTypeRSA KeyType = 1 + iota // KeyType RSA
+	KeyTypeEC                     // KeyType EC
+)
+
+// KeySpec defines a key type and size.
+type KeySpec struct {
+	Type KeyType
+	Size int
+}
+
+// ExtractKeySpec extracts KeySpec from the signing certificate.
+func ExtractKeySpec(signingCert *x509.Certificate) (KeySpec, error) {
+	switch key := signingCert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		switch bitSize := key.Size() << 3; bitSize {
+		case 2048, 3072, 4096:
+			return KeySpec{
+				Type: KeyTypeRSA,
+				Size: bitSize,
+			}, nil
+		default:
+			return KeySpec{}, &UnsupportedSigningKeyError{
+				Msg: fmt.Sprintf("rsa key size %d is not supported", bitSize),
+			}
+		}
+	case *ecdsa.PublicKey:
+		switch bitSize := key.Curve.Params().BitSize; bitSize {
+		case 256, 384, 521:
+			return KeySpec{
+				Type: KeyTypeEC,
+				Size: bitSize,
+			}, nil
+		default:
+			return KeySpec{}, &UnsupportedSigningKeyError{
+				Msg: fmt.Sprintf("ecdsa key size %d is not supported", bitSize),
+			}
+		}
+	}
+	return KeySpec{}, &UnsupportedSigningKeyError{
+		Msg: "invalid public key type",
+	}
+}

--- a/signature/algorithm_test.go
+++ b/signature/algorithm_test.go
@@ -1,0 +1,103 @@
+package signature
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/notaryproject/notation-core-go/testhelper"
+)
+
+func TestExtractKeySpec(t *testing.T) {
+	type testCase struct {
+		name      string
+		cert      *x509.Certificate
+		expect    KeySpec
+		expectErr bool
+	}
+	// invalid cases
+	tests := []testCase{
+		{
+			name:      "RSA wrong size",
+			cert:      testhelper.GetUnsupportedRSACert().Cert,
+			expect:    KeySpec{},
+			expectErr: true,
+		},
+		{
+			name:      "ECDSA wrong size",
+			cert:      testhelper.GetUnsupportedECCert().Cert,
+			expect:    KeySpec{},
+			expectErr: true,
+		},
+		{
+			name: "Unsupported type",
+			cert: &x509.Certificate{
+				PublicKey: ed25519.PublicKey{},
+			},
+			expect:    KeySpec{},
+			expectErr: true,
+		},
+	}
+
+	// append valid RSA cases
+	for _, k := range []int{2048, 3072, 4096} {
+		rsaRoot := testhelper.GetRSARootCertificate()
+		priv, _ := rsa.GenerateKey(rand.Reader, k)
+
+		certTuple := testhelper.GetRSACertTupleWithPK(
+			priv,
+			"Test RSA_"+strconv.Itoa(priv.Size()),
+			&rsaRoot,
+		)
+		tests = append(tests, testCase{
+			name: "RSA " + strconv.Itoa(k),
+			cert: certTuple.Cert,
+			expect: KeySpec{
+				Type: KeyTypeRSA,
+				Size: k,
+			},
+			expectErr: false,
+		})
+	}
+
+	// append valid EDCSA cases
+	for _, curve := range []elliptic.Curve{elliptic.P256(), elliptic.P384(), elliptic.P521()} {
+		ecdsaRoot := testhelper.GetECRootCertificate()
+		priv, _ := ecdsa.GenerateKey(curve, rand.Reader)
+		bitSize := priv.Params().BitSize
+
+		certTuple := testhelper.GetECDSACertTupleWithPK(
+			priv,
+			"Test EC_"+strconv.Itoa(bitSize),
+			&ecdsaRoot,
+		)
+		tests = append(tests, testCase{
+			name: "EC " + strconv.Itoa(bitSize),
+			cert: certTuple.Cert,
+			expect: KeySpec{
+				Type: KeyTypeEC,
+				Size: bitSize,
+			},
+			expectErr: false,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keySpec, err := ExtractKeySpec(tt.cert)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(keySpec, tt.expect) {
+				t.Errorf("expect %+v, got %+v", tt.expect, keySpec)
+			}
+		})
+	}
+}

--- a/signature/algorithm_test.go
+++ b/signature/algorithm_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -13,6 +14,59 @@ import (
 
 	"github.com/notaryproject/notation-core-go/testhelper"
 )
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		name   string
+		alg    Algorithm
+		expect crypto.Hash
+	}{
+		{
+			name:   "PS256",
+			alg:    AlgorithmPS256,
+			expect: crypto.SHA256,
+		},
+		{
+			name:   "ES256",
+			alg:    AlgorithmES256,
+			expect: crypto.SHA256,
+		},
+		{
+			name:   "PS384",
+			alg:    AlgorithmPS384,
+			expect: crypto.SHA384,
+		},
+		{
+			name:   "ES384",
+			alg:    AlgorithmES384,
+			expect: crypto.SHA384,
+		},
+		{
+			name:   "PS512",
+			alg:    AlgorithmPS512,
+			expect: crypto.SHA512,
+		},
+		{
+			name:   "ES512",
+			alg:    AlgorithmES512,
+			expect: crypto.SHA512,
+		},
+		{
+			name:   "UnsupportedAlgorithm",
+			alg:    0,
+			expect: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := tt.alg.Hash()
+			if hash != tt.expect {
+				t.Fatalf("Expected %v, got %v", tt.expect, hash)
+			}
+		})
+	}
+}
 
 func TestExtractKeySpec(t *testing.T) {
 	type testCase struct {

--- a/signature/errors.go
+++ b/signature/errors.go
@@ -88,11 +88,11 @@ func (e *SignatureIntegrityError) Unwrap() error {
 	return e.Err
 }
 
-// SignatureNotFoundError is used when signature envelope is not present.
-type SignatureNotFoundError struct{}
+// SignatureEnvelopeNotFoundError is used when signature envelope is not present.
+type SignatureEnvelopeNotFoundError struct{}
 
 // Error returns the default error message.
-func (e *SignatureNotFoundError) Error() string {
+func (e *SignatureEnvelopeNotFoundError) Error() string {
 	return "signature envelope is not present"
 }
 

--- a/signature/errors.go
+++ b/signature/errors.go
@@ -1,0 +1,126 @@
+package signature
+
+import (
+	"fmt"
+)
+
+// MalformedSignatureError is used when Signature envelope is malformed.
+type MalformedSignatureError struct {
+	Msg string
+}
+
+// Error returns the error message or the default message if not provided.
+func (e *MalformedSignatureError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "signature envelope format is malformed"
+}
+
+// UnsupportedSigningKeyError is used when a signing key is not supported.
+type UnsupportedSigningKeyError struct {
+	Msg string
+}
+
+// Error returns the error message or the default message if not provided.
+func (e *UnsupportedSigningKeyError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "signing key is not supported"
+}
+
+// MalformedArgumentError is used when an argument to a function is malformed.
+type MalformedArgumentError struct {
+	Param string
+	Err   error
+}
+
+// Error returns the error message.
+func (e *MalformedArgumentError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%q param is malformed. Error: %s", e.Param, e.Err.Error())
+	}
+	return fmt.Sprintf("%q param is malformed", e.Param)
+}
+
+// Unwrap returns the unwrapped error
+func (e *MalformedArgumentError) Unwrap() error {
+	return e.Err
+}
+
+// MalformedSignRequestError is used when SignRequest is malformed.
+type MalformedSignRequestError struct {
+	Msg string
+}
+
+// Error returns the error message or the default message if not provided.
+func (e *MalformedSignRequestError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "SignRequest is malformed"
+}
+
+// SignatureAlgoNotSupportedError is used when signing algo is not supported.
+type SignatureAlgoNotSupportedError struct {
+	Alg string
+}
+
+// Error returns the formatted error message.
+func (e *SignatureAlgoNotSupportedError) Error() string {
+	return fmt.Sprintf("signature algorithm %q is not supported", e.Alg)
+}
+
+// SignatureIntegrityError is used when the signature associated is no longer
+// valid.
+type SignatureIntegrityError struct {
+	Err error
+}
+
+// Error returns the formatted error message.
+func (e *SignatureIntegrityError) Error() string {
+	return fmt.Sprintf("signature is invalid. Error: %s", e.Err.Error())
+}
+
+// Unwrap unwraps the internal error.
+func (e *SignatureIntegrityError) Unwrap() error {
+	return e.Err
+}
+
+// SignatureNotFoundError is used when signature envelope is not present.
+type SignatureNotFoundError struct{}
+
+// Error returns the default error message.
+func (e *SignatureNotFoundError) Error() string {
+	return "signature envelope is not present"
+}
+
+// SignatureAuthenticityError is used when signature is not generated using
+// trusted certificates.
+type SignatureAuthenticityError struct{}
+
+// Error returns the default error message.
+func (e *SignatureAuthenticityError) Error() string {
+	return "signature is not produced by a trusted signer"
+}
+
+// UnsupportedSignatureFormatError is used when Signature envelope is not supported.
+type UnsupportedSignatureFormatError struct {
+	MediaType string
+}
+
+// Error returns the formatted error message.
+func (e *UnsupportedSignatureFormatError) Error() string {
+	return fmt.Sprintf("signature envelope format with media type %q is not supported", e.MediaType)
+}
+
+// EnvelopeKeyRepeatedError is used when repeated key name found in the envelope.
+type EnvelopeKeyRepeatedError struct {
+	Key string
+}
+
+// Error returns the formatted error message.
+func (e *EnvelopeKeyRepeatedError) Error() string {
+	return fmt.Sprintf("repeated key: %q exists in the envelope.", e.Key)
+}

--- a/signature/errors_test.go
+++ b/signature/errors_test.go
@@ -165,7 +165,7 @@ func TestSignatureIntegrityError(t *testing.T) {
 	}
 }
 
-func TestSignatureNotFoundError(t *testing.T) {
+func TestSignatureEnvelopeNotFoundError(t *testing.T) {
 	err := &SignatureEnvelopeNotFoundError{}
 	expectMsg := "signature envelope is not present"
 

--- a/signature/errors_test.go
+++ b/signature/errors_test.go
@@ -1,0 +1,202 @@
+package signature
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+const (
+	errMsg        = "error msg"
+	testParam     = "test param"
+	testAlg       = "test algorithm"
+	testMediaType = "test media type"
+)
+
+func TestMalformedSignatureError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    *MalformedSignatureError
+		expect string
+	}{
+		{
+			name:   "err msg set",
+			err:    &MalformedSignatureError{Msg: errMsg},
+			expect: errMsg,
+		},
+		{
+			name:   "err msg not set",
+			err:    &MalformedSignatureError{},
+			expect: "signature envelope format is malformed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg != tt.expect {
+				t.Errorf("Expected %s but got %s", tt.expect, msg)
+			}
+		})
+	}
+}
+
+func TestUnsupportedSigningKeyError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    *UnsupportedSigningKeyError
+		expect string
+	}{
+		{
+			name:   "err msg set",
+			err:    &UnsupportedSigningKeyError{Msg: errMsg},
+			expect: errMsg,
+		},
+		{
+			name:   "err msg not set",
+			err:    &UnsupportedSigningKeyError{},
+			expect: "signing key is not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg != tt.expect {
+				t.Errorf("Expected %s but got %s", tt.expect, msg)
+			}
+		})
+	}
+}
+
+func TestMalformedArgumentError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    *MalformedArgumentError
+		expect string
+	}{
+		{
+			name: "err set",
+			err: &MalformedArgumentError{
+				Param: testParam,
+				Err:   errors.New(errMsg),
+			},
+			expect: fmt.Sprintf("%q param is malformed. Error: %s", testParam, errMsg),
+		},
+		{
+			name:   "err not set",
+			err:    &MalformedArgumentError{Param: testParam},
+			expect: fmt.Sprintf("%q param is malformed", testParam),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg != tt.expect {
+				t.Errorf("Expected %s but got %s", tt.expect, msg)
+			}
+		})
+	}
+}
+
+func TestMalformedArgumentError_Unwrap(t *testing.T) {
+	err := &MalformedArgumentError{
+		Param: testParam,
+		Err:   errors.New(errMsg),
+	}
+	unwrappedErr := err.Unwrap()
+	if unwrappedErr.Error() != errMsg {
+		t.Errorf("Expected %s but got %s", errMsg, unwrappedErr.Error())
+	}
+}
+
+func TestMalformedSignRequestError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    *MalformedSignRequestError
+		expect string
+	}{
+		{
+			name:   "err msg set",
+			err:    &MalformedSignRequestError{Msg: errMsg},
+			expect: errMsg,
+		},
+		{
+			name:   "err msg not set",
+			err:    &MalformedSignRequestError{},
+			expect: "SignRequest is malformed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg != tt.expect {
+				t.Errorf("Expected %s but got %s", tt.expect, msg)
+			}
+		})
+	}
+}
+
+func TestSignatureAlgoNotSupportedError(t *testing.T) {
+	err := &SignatureAlgoNotSupportedError{
+		Alg: testAlg,
+	}
+
+	expectMsg := fmt.Sprintf("signature algorithm %q is not supported", testAlg)
+	if err.Error() != expectMsg {
+		t.Errorf("Expected %s but got %s", expectMsg, err.Error())
+	}
+}
+
+func TestSignatureIntegrityError(t *testing.T) {
+	unwrappedErr := errors.New(errMsg)
+	err := &SignatureIntegrityError{
+		Err: unwrappedErr,
+	}
+
+	expectMsg := fmt.Sprintf("signature is invalid. Error: %s", errMsg)
+	if err.Error() != expectMsg {
+		t.Errorf("Expected %s but got %s", expectMsg, err.Error())
+	}
+	if err.Unwrap() != unwrappedErr {
+		t.Errorf("Expected %v but got %v", unwrappedErr, err.Unwrap())
+	}
+}
+
+func TestSignatureNotFoundError(t *testing.T) {
+	err := &SignatureNotFoundError{}
+	expectMsg := "signature envelope is not present"
+
+	if err.Error() != expectMsg {
+		t.Errorf("Expected %v but got %v", expectMsg, err.Error())
+	}
+}
+
+func TestSignatureAuthenticityError(t *testing.T) {
+	err := &SignatureAuthenticityError{}
+	expectMsg := "signature is not produced by a trusted signer"
+
+	if err.Error() != expectMsg {
+		t.Errorf("Expected %v but got %v", expectMsg, err.Error())
+	}
+}
+
+func TestUnsupportedSignatureFormatError(t *testing.T) {
+	err := &UnsupportedSignatureFormatError{MediaType: testMediaType}
+	expectMsg := fmt.Sprintf("signature envelope format with media type %q is not supported", testMediaType)
+
+	if err.Error() != expectMsg {
+		t.Errorf("Expected %v but got %v", expectMsg, err.Error())
+	}
+}
+
+func TestEnvelopeKeyRepeatedError(t *testing.T) {
+	err := &EnvelopeKeyRepeatedError{Key: errMsg}
+	expectMsg := fmt.Sprintf("repeated key: %q exists in the envelope.", errMsg)
+
+	if err.Error() != expectMsg {
+		t.Errorf("Expected %v but got %v", expectMsg, err.Error())
+	}
+}

--- a/signature/errors_test.go
+++ b/signature/errors_test.go
@@ -166,7 +166,7 @@ func TestSignatureIntegrityError(t *testing.T) {
 }
 
 func TestSignatureNotFoundError(t *testing.T) {
-	err := &SignatureNotFoundError{}
+	err := &SignatureEnvelopeNotFoundError{}
 	expectMsg := "signature envelope is not present"
 
 	if err.Error() != expectMsg {

--- a/signature/signer.go
+++ b/signature/signer.go
@@ -124,8 +124,8 @@ func VerifyAuthenticity(signerInfo *SignerInfo, trustedCerts []*x509.Certificate
 	}
 
 	for _, trust := range trustedCerts {
-		for _, sig := range signerInfo.CertificateChain {
-			if trust.Equal(sig) {
+		for _, cert := range signerInfo.CertificateChain {
+			if trust.Equal(cert) {
 				return trust, nil
 			}
 		}

--- a/signature/signer.go
+++ b/signature/signer.go
@@ -1,0 +1,134 @@
+package signature
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+)
+
+// Signer is used to sign bytes generated after signature envelope created.
+type Signer interface {
+	// Sign signs the payload and returns the raw signature and certificates.
+	Sign(payload []byte) ([]byte, []*x509.Certificate, error)
+
+	// KeySpec returns the key specification.
+	KeySpec() (KeySpec, error)
+}
+
+// LocalSigner is used by built-in signers to sign only.
+type LocalSigner interface {
+	Signer
+
+	// CertificateChain returns the certificate chain.
+	CertificateChain() ([]*x509.Certificate, error)
+
+	// PrivateKey returns the private key.
+	PrivateKey() crypto.PrivateKey
+}
+
+// localSigner implements LocalSigner interface.
+//
+// Note that localSigner only holds the signing key, keySpec and certificate
+// chain. The underlying signing implementation is provided by the underlying
+// crypto library for the specific signature format like go-jwt or go-cose.
+type localSigner struct {
+	keySpec KeySpec
+	key     crypto.PrivateKey
+	certs   []*x509.Certificate
+}
+
+// NewLocalSigner returns a new signer with given certificates and private key.
+func NewLocalSigner(certs []*x509.Certificate, key crypto.PrivateKey) (LocalSigner, error) {
+	if len(certs) == 0 {
+		return nil, &MalformedArgumentError{
+			Param: "certs",
+			Err:   errors.New("empty certs"),
+		}
+	}
+
+	keySpec, err := ExtractKeySpec(certs[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if !isKeyPair(key, certs[0].PublicKey, keySpec) {
+		return nil, &MalformedArgumentError{
+			Param: "key and certs",
+			Err:   errors.New("key not matches certificate"),
+		}
+	}
+
+	return &localSigner{
+		keySpec: keySpec,
+		key:     key,
+		certs:   certs,
+	}, nil
+}
+
+// isKeyPair checks if the private key matches the provided public key.
+func isKeyPair(priv crypto.PrivateKey, pub crypto.PublicKey, keySpec KeySpec) bool {
+	switch keySpec.Type {
+	case KeyTypeRSA:
+		privateKey, ok := priv.(*rsa.PrivateKey)
+		if !ok {
+			return false
+		}
+		return privateKey.PublicKey.Equal(pub)
+	case KeyTypeEC:
+		privateKey, ok := priv.(*ecdsa.PrivateKey)
+		if !ok {
+			return false
+		}
+		return privateKey.PublicKey.Equal(pub)
+	default:
+		return false
+	}
+}
+
+// Sign signs the content and returns the raw signature and certificates.
+// This implementation should never be used by built-in signers.
+func (s *localSigner) Sign(content []byte) ([]byte, []*x509.Certificate, error) {
+	return nil, nil, fmt.Errorf("local signer doesn't support sign")
+}
+
+// KeySpec returns the key specification.
+func (s *localSigner) KeySpec() (KeySpec, error) {
+	return s.keySpec, nil
+}
+
+// CertificateChain returns the certificate chain.
+func (s *localSigner) CertificateChain() ([]*x509.Certificate, error) {
+	return s.certs, nil
+}
+
+// PrivateKey returns the private key.
+func (s *localSigner) PrivateKey() crypto.PrivateKey {
+	return s.key
+}
+
+// VerifyAuthenticity verifies the certificate chain in the given SignerInfo
+// with one of the trusted certificates and returns a certificate that matches
+// with one of the certificates in the SignerInfo.
+//
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/trust-store-trust-policy-specification.md#steps
+func VerifyAuthenticity(signerInfo *SignerInfo, trustedCerts []*x509.Certificate) (*x509.Certificate, error) {
+	if len(trustedCerts) == 0 {
+		return nil, &MalformedArgumentError{Param: "trustedCerts"}
+	}
+
+	if signerInfo == nil {
+		return nil, &MalformedArgumentError{Param: "signerInfo"}
+	}
+
+	for _, trust := range trustedCerts {
+		for _, sig := range signerInfo.CertificateChain {
+			if trust.Equal(sig) {
+				return trust, nil
+			}
+		}
+	}
+	return nil, &SignatureAuthenticityError{}
+}

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -1,0 +1,226 @@
+package signature
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/x509"
+	"reflect"
+	"testing"
+
+	"github.com/notaryproject/notation-core-go/testhelper"
+)
+
+func TestNewLocalSigner(t *testing.T) {
+	tests := []struct {
+		name      string
+		certs     []*x509.Certificate
+		key       crypto.PrivateKey
+		expect    LocalSigner
+		expectErr bool
+	}{
+		{
+			name:      "empty certs",
+			certs:     make([]*x509.Certificate, 0),
+			key:       nil,
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "unsupported leaf cert",
+			certs: []*x509.Certificate{
+				{PublicKey: ed25519.PublicKey{}},
+			},
+			key:       nil,
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "keys not match",
+			certs: []*x509.Certificate{
+				testhelper.GetECLeafCertificate().Cert,
+			},
+			key:       testhelper.GetRSARootCertificate().PrivateKey,
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "keys not match",
+			certs: []*x509.Certificate{
+				testhelper.GetRSARootCertificate().Cert,
+			},
+			key:       testhelper.GetECLeafCertificate().PrivateKey,
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "RSA keys match",
+			certs: []*x509.Certificate{
+				testhelper.GetRSALeafCertificate().Cert,
+			},
+			key: testhelper.GetRSALeafCertificate().PrivateKey,
+			expect: &localSigner{
+				keySpec: KeySpec{
+					Type: KeyTypeRSA,
+					Size: 3072,
+				},
+				key: testhelper.GetRSALeafCertificate().PrivateKey,
+				certs: []*x509.Certificate{
+					testhelper.GetRSALeafCertificate().Cert,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "EC keys match",
+			certs: []*x509.Certificate{
+				testhelper.GetECLeafCertificate().Cert,
+			},
+			key: testhelper.GetECLeafCertificate().PrivateKey,
+			expect: &localSigner{
+				keySpec: KeySpec{
+					Type: KeyTypeEC,
+					Size: 384,
+				},
+				key: testhelper.GetECLeafCertificate().PrivateKey,
+				certs: []*x509.Certificate{
+					testhelper.GetECLeafCertificate().Cert,
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer, err := NewLocalSigner(tt.certs, tt.key)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(signer, tt.expect) {
+				t.Errorf("expect %+v, got %+v", tt.expect, signer)
+			}
+		})
+	}
+}
+
+func TestSign(t *testing.T) {
+	signer := &localSigner{}
+
+	raw, certs, err := signer.Sign(make([]byte, 0))
+	if err == nil {
+		t.Errorf("expect error but got nil")
+	}
+	if raw != nil {
+		t.Errorf("expect nil raw signature but got %v", raw)
+	}
+	if certs != nil {
+		t.Errorf("expect nil certs but got %v", certs)
+	}
+}
+
+func TestKeySpec(t *testing.T) {
+	expectKeySpec := KeySpec{
+		Type: KeyTypeRSA,
+		Size: 256,
+	}
+	signer := &localSigner{keySpec: expectKeySpec}
+
+	keySpec, err := signer.KeySpec()
+
+	if err != nil {
+		t.Errorf("expect no error but got %v", err)
+	}
+	if !reflect.DeepEqual(keySpec, expectKeySpec) {
+		t.Errorf("expect keySpec %+v, got %+v", expectKeySpec, keySpec)
+	}
+}
+
+func TestCertificateChain(t *testing.T) {
+	expectCerts := []*x509.Certificate{
+		testhelper.GetRSALeafCertificate().Cert,
+	}
+	signer := &localSigner{certs: expectCerts}
+
+	certs, err := signer.CertificateChain()
+
+	if err != nil {
+		t.Errorf("expect no error but got %v", err)
+	}
+	if !reflect.DeepEqual(certs, expectCerts) {
+		t.Errorf("expect certs %+v, got %+v", expectCerts, certs)
+	}
+}
+
+func TestPrivateKey(t *testing.T) {
+	expectKey := testhelper.GetRSALeafCertificate().PrivateKey
+	signer := &localSigner{key: expectKey}
+
+	key := signer.PrivateKey()
+
+	if !reflect.DeepEqual(key, expectKey) {
+		t.Errorf("expect key %+v, got %+v", expectKey, key)
+	}
+}
+
+func TestVerifyAuthenticity(t *testing.T) {
+	tests := []struct {
+		name       string
+		signerInfo *SignerInfo
+		certs      []*x509.Certificate
+		expect     *x509.Certificate
+		expectErr  bool
+	}{
+		{
+			name:       "empty certs",
+			signerInfo: nil,
+			certs:      make([]*x509.Certificate, 0),
+			expect:     nil,
+			expectErr:  true,
+		},
+		{
+			name:       "nil signerInfo",
+			signerInfo: nil,
+			certs: []*x509.Certificate{
+				testhelper.GetECLeafCertificate().Cert,
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name:       "no cert matches",
+			signerInfo: &SignerInfo{},
+			certs: []*x509.Certificate{
+				testhelper.GetECLeafCertificate().Cert,
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "cert matches",
+			signerInfo: &SignerInfo{
+				CertificateChain: []*x509.Certificate{
+					testhelper.GetECLeafCertificate().Cert,
+				},
+			},
+			certs: []*x509.Certificate{
+				testhelper.GetECLeafCertificate().Cert,
+			},
+			expect:    testhelper.GetECLeafCertificate().Cert,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert, err := VerifyAuthenticity(tt.signerInfo, tt.certs)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(cert, tt.expect) {
+				t.Errorf("expect cert %+v, got %+v", tt.expect, cert)
+			}
+		})
+	}
+}

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -20,7 +20,7 @@ func TestNewLocalSigner(t *testing.T) {
 	}{
 		{
 			name:      "empty certs",
-			certs:     make([]*x509.Certificate, 0),
+			certs:     []*x509.Certificate{},
 			key:       nil,
 			expect:    nil,
 			expectErr: true,
@@ -107,7 +107,7 @@ func TestNewLocalSigner(t *testing.T) {
 func TestSign(t *testing.T) {
 	signer := &localSigner{}
 
-	raw, certs, err := signer.Sign(make([]byte, 0))
+	raw, certs, err := signer.Sign([]byte{})
 	if err == nil {
 		t.Errorf("expect error but got nil")
 	}

--- a/signature/types.go
+++ b/signature/types.go
@@ -1,0 +1,107 @@
+package signature
+
+import (
+	"crypto/x509"
+	"errors"
+	"time"
+)
+
+// MediaTypePayloadV1 is the supported content type for signature's payload.
+const MediaTypePayloadV1 = "application/vnd.cncf.notary.payload.v1+json"
+
+// SigningScheme formalizes the feature set (guarantees) provided by
+// the signature.
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/signing-scheme.md
+type SigningScheme string
+
+// SigningSchemes supported by notation.
+const (
+	// notary.x509 signing scheme.
+	SigningSchemeX509 SigningScheme = "notary.x509"
+
+	// notary.x509.signingAuthority schema.
+	SigningSchemeX509SigningAuthority SigningScheme = "notary.x509.signingAuthority"
+)
+
+// SignedAttributes represents signed metadata in the signature envelope.
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#signed-attributes
+type SignedAttributes struct {
+	// SigningScheme defines the Notary v2 Signing Scheme used by the signature.
+	SigningScheme SigningScheme
+
+	// SigningTime indicates the time at which the signature was generated.
+	SigningTime time.Time
+
+	// Expiry provides a “best by use” time for the artifact.
+	Expiry time.Time
+
+	// additional signed attributes in the signature envelope.
+	ExtendedAttributes []Attribute
+}
+
+// UnsignedAttributes represents unsigned metadata in the Signature envelope.
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#unsigned-attributes
+type UnsignedAttributes struct {
+	// TimestampSignature is a counter signature providing authentic timestamp.
+	TimestampSignature []byte
+
+	// SigningAgent provides the identifier of the software (e.g. Notation) that
+	// produces the signature on behalf of the user.
+	SigningAgent string
+}
+
+// Attribute represents metadata in the Signature envelope.
+type Attribute struct {
+	// Key is the key name of the attribute.
+	Key string
+
+	// Critical marks the attribute that MUST be processed by a verifier.
+	Critical bool
+
+	// Value is the value of the attribute.
+	Value interface{}
+}
+
+// SignerInfo represents a parsed signature envelope that is agnostic to
+// signature envelope format.
+type SignerInfo struct {
+	// SignedAttributes are additional metadata required to support the
+	// signature verification process.
+	SignedAttributes SignedAttributes
+
+	// UnsignedAttributes are considered unsigned with respect to the signing
+	// key that generates the signature.
+	UnsignedAttributes UnsignedAttributes
+
+	// SignatureAlgorithm defines the signature algorithm.
+	SignatureAlgorithm Algorithm
+
+	// CertificateChain is an ordered list of X.509 public certificates
+	// associated with the signing key used to generate the signature.
+	// The ordered list starts with the signing certificates, any intermediate
+	// certificates and ends with the root certificate.
+	CertificateChain []*x509.Certificate
+
+	// Signature is the bytes generated from the signature.
+	Signature []byte
+}
+
+// Payload represents payload in bytes and its content type.
+type Payload struct {
+	// ContentType specifies the content type of payload.
+	ContentType string
+
+	// Content contains the raw bytes of the payload.
+	Content []byte
+}
+
+// ExtendedAttribute fetches the specified Attribute with provided key from
+// signerInfo.SignedAttributes.ExtendedAttributes
+func (signerInfo *SignerInfo) ExtendedAttribute(key string) (Attribute, error) {
+	for _, attr := range signerInfo.SignedAttributes.ExtendedAttributes {
+		if attr.Key == key {
+			return attr, nil
+		}
+	}
+	return Attribute{}, errors.New("key not in ExtendedAttributes")
+}

--- a/signature/types.go
+++ b/signature/types.go
@@ -96,7 +96,7 @@ type Payload struct {
 }
 
 // ExtendedAttribute fetches the specified Attribute with provided key from
-// signerInfo.SignedAttributes.ExtendedAttributes
+// signerInfo.SignedAttributes.ExtendedAttributes.
 func (signerInfo *SignerInfo) ExtendedAttribute(key string) (Attribute, error) {
 	for _, attr := range signerInfo.SignedAttributes.ExtendedAttributes {
 		if attr.Key == key {

--- a/testhelper/certificatetest.go
+++ b/testhelper/certificatetest.go
@@ -20,7 +20,7 @@ var (
 	ecdsaRoot            ECCertTuple
 	ecdsaLeaf            ECCertTuple
 	unsupportedECDSARoot ECCertTuple
-	unsupported          RSACertTuple
+	unsupportedRSARoot   RSACertTuple
 )
 
 type RSACertTuple struct {
@@ -58,16 +58,10 @@ func GetECLeafCertificate() ECCertTuple {
 	return ecdsaLeaf
 }
 
-// GetUnsupportedCertificate returns certificate signed using RSA algorithm with key size of 1024 bits
-// which is not supported by notary.
-func GetUnsupportedCertificate() RSACertTuple {
-	return unsupported
-}
-
 // GetUnsupportedRSACert returns certificate signed using RSA algorithm with key
 // size of 1024 bits which is not supported by notary.
 func GetUnsupportedRSACert() RSACertTuple {
-	return unsupported
+	return unsupportedRSARoot
 }
 
 // GetUnsupportedECCert returns certificate signed using EC algorithm with P-224
@@ -86,7 +80,7 @@ func setupCertificates() {
 	// This will be flagged by the static code analyzer as 'Use of a weak cryptographic key' but its intentional
 	// and is used only for testing.
 	k, _ := rsa.GenerateKey(rand.Reader, 1024)
-	unsupported = GetRSACertTupleWithPK(k, "Notation Unsupported Root", nil)
+	unsupportedRSARoot = GetRSACertTupleWithPK(k, "Notation Unsupported Root", nil)
 }
 
 func getCertTuple(cn string, issuer *RSACertTuple) RSACertTuple {

--- a/testhelper/certificatetest.go
+++ b/testhelper/certificatetest.go
@@ -10,15 +10,17 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"strconv"
 	"time"
 )
 
 var (
-	rsaRoot     RSACertTuple
-	rsaLeaf     RSACertTuple
-	ecdsaRoot   ECCertTuple
-	ecdsaLeaf   ECCertTuple
-	unsupported RSACertTuple
+	rsaRoot              RSACertTuple
+	rsaLeaf              RSACertTuple
+	ecdsaRoot            ECCertTuple
+	ecdsaLeaf            ECCertTuple
+	unsupportedECDSARoot ECCertTuple
+	unsupported          RSACertTuple
 )
 
 type RSACertTuple struct {
@@ -62,11 +64,24 @@ func GetUnsupportedCertificate() RSACertTuple {
 	return unsupported
 }
 
+// GetUnsupportedRSACert returns certificate signed using RSA algorithm with key
+// size of 1024 bits which is not supported by notary.
+func GetUnsupportedRSACert() RSACertTuple {
+	return unsupported
+}
+
+// GetUnsupportedECCert returns certificate signed using EC algorithm with P-224
+// curve which is not supported by notary.
+func GetUnsupportedECCert() ECCertTuple {
+	return unsupportedECDSARoot
+}
+
 func setupCertificates() {
 	rsaRoot = getCertTuple("Notation Test Root", nil)
 	rsaLeaf = getCertTuple("Notation Test Leaf Cert", &rsaRoot)
 	ecdsaRoot = getECCertTuple("Notation Test Root2", nil)
 	ecdsaLeaf = getECCertTuple("Notation Test Leaf Cert", &ecdsaRoot)
+	unsupportedECDSARoot = getECCertTupleWithCurve("Notation Test Invalid ECDSA Cert", nil, elliptic.P224())
 
 	// This will be flagged by the static code analyzer as 'Use of a weak cryptographic key' but its intentional
 	// and is used only for testing.
@@ -77,6 +92,11 @@ func setupCertificates() {
 func getCertTuple(cn string, issuer *RSACertTuple) RSACertTuple {
 	pk, _ := rsa.GenerateKey(rand.Reader, 3072)
 	return GetRSACertTupleWithPK(pk, cn, issuer)
+}
+
+func getECCertTupleWithCurve(cn string, issuer *ECCertTuple, curve elliptic.Curve) ECCertTuple {
+	k, _ := ecdsa.GenerateKey(curve, rand.Reader)
+	return GetECDSACertTupleWithPK(k, cn, issuer)
 }
 
 func getECCertTuple(cn string, issuer *ECCertTuple) ECCertTuple {
@@ -146,4 +166,29 @@ func getCertTemplate(isRoot bool, cn string) *x509.Certificate {
 	}
 
 	return template
+}
+
+func GetRSACertTuple(size int) RSACertTuple {
+	rsaRoot := GetRSARootCertificate()
+	priv, _ := rsa.GenerateKey(rand.Reader, size)
+
+	certTuple := GetRSACertTupleWithPK(
+		priv,
+		"Test RSA_"+strconv.Itoa(priv.Size()),
+		&rsaRoot,
+	)
+	return certTuple
+}
+
+func GetECCertTuple(curve elliptic.Curve) ECCertTuple {
+	ecdsaRoot := GetECRootCertificate()
+	priv, _ := ecdsa.GenerateKey(curve, rand.Reader)
+	bitSize := priv.Params().BitSize
+
+	certTuple := GetECDSACertTupleWithPK(
+		priv,
+		"Test EC_"+strconv.Itoa(bitSize),
+		&ecdsaRoot,
+	)
+	return certTuple
 }


### PR DESCRIPTION
### What?

Background can be checked out in https://github.com/notaryproject/notation/discussions/278

1. Created a new `signature` submodule to refactor the original `signer` submodule. 
2. Renamed the original `SignatureProvider` to `Signer`. 
3. Created `LocalSigner` to support native signing implementation provided by underlying crypto libraries, e.g. go-cose, go-jwt.
4. Other refactoring on the algorithm and keySpec definitions.

### Test?
Added corresponding unit tests.


Signed-off-by: Binbin Li <libinbin@microsoft.com>