### PR TITLE
refactor: rename signer to signature submodule

### DIFF
--- a/signature/errors.go
+++ b/signature/errors.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import "fmt"
 

--- a/signature/errors_test.go
+++ b/signature/errors_test.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"fmt"

--- a/signature/jws.go
+++ b/signature/jws.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto/x509"

--- a/signature/jws_test.go
+++ b/signature/jws_test.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto/rand"

--- a/signature/jwt.go
+++ b/signature/jwt.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto"

--- a/signature/jwt_test.go
+++ b/signature/jwt_test.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto/ecdsa"

--- a/signature/signer.go
+++ b/signature/signer.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto/x509"

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto/x509"

--- a/signature/types.go
+++ b/signature/types.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import "crypto"
 

--- a/signature/utils.go
+++ b/signature/utils.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto"

--- a/signature/utils_test.go
+++ b/signature/utils_test.go
@@ -1,4 +1,4 @@
-package signer
+package signature
 
 import (
 	"crypto"


### PR DESCRIPTION
### What?

1. Rename signer submodule to signature submodule.
2. Update the package name accordingly.

Signed-off-by: Binbin Li <libinbin@microsoft.com>