### PR TITLE
update: updated COSE extended attributes logic

### DIFF
--- a/signature/cose/conformance_test.go
+++ b/signature/cose/conformance_test.go
@@ -185,12 +185,8 @@ func verifyPayload(payload *signature.Payload, request *signature.SignRequest, t
 }
 
 func areAttrEqual(u []signature.Attribute, v []signature.Attribute) bool {
-	sort.Slice(u, func(p, q int) bool {
-		return u[p].Key < u[q].Key
-	})
-	sort.Slice(v, func(p, q int) bool {
-		return v[p].Key < v[q].Key
-	})
+	sortCOSEAttributes(u)
+	sortCOSEAttributes(v)
 	return reflect.DeepEqual(u, v)
 }
 
@@ -201,4 +197,26 @@ func generateSign1(msg *cose.Sign1Message) *cose.Sign1Message {
 	newMsg.Payload = msg.Payload
 	newMsg.Signature = hexToBytes("31b6cb0cd9c974b39d603465811c2aa3d96a5dff89f80b33cb4e321dc6e68a29b4ba65c00f0f9f22ee4376abfaec2cba6fd21c6881ecaab25775e3fb9226a88cf41660b2d6fd14184540d07ded3744e19ff9dbdd081e15c8f77bb6ca3072ef57141594fad4ea57d206c6b8dd3a6e0a0a7ed764ff08dbcc439bd722e1b3d282921a579a3d860cceea37d633184f9316cb6b4fa4ea550da5ad9e5bf3c2d768a787da76e594290cb10b5b1ead8b7e75967de28e9ff429fe9db814380608a15674f9741563902a620f312213d9dce5c264017cbcb3bb4f8cebee0d5ef32b364f68c11cba5630fac8e3165d06fdebaca095267223c552fe605b4529f25b65f8fa47b010b9096cec275307e82b1062f660a73e07d0b85b978b4a59b5cde51fc9a031b488a3deb38fc312a64ef2ec1250238ae16cfefc00d9aa1ceb938fe6de51f265eebe975c29f4cff8ab0afb40c45e8c985d17347bf20f455851c1a46ab655f51a159cf8910a424c5a8bbdd239e49e43a73c7b5174de29e835063e5e64b459558de5")
 	return newMsg
+}
+
+func sortCOSEAttributes(u []signature.Attribute) {
+	sort.Slice(u, func(p, q int) bool {
+		switch k1 := u[p].Key.(type) {
+		case int:
+			switch k2 := u[q].Key.(type) {
+			case int:
+				return k1 < k2
+			case string:
+				return false
+			}
+		case string:
+			switch k2 := u[q].Key.(type) {
+			case int:
+				return true
+			case string:
+				return k1 < k2
+			}
+		}
+		return false
+	})
 }

--- a/signature/cose/envelope.go
+++ b/signature/cose/envelope.go
@@ -551,11 +551,6 @@ func generateExtendedAttributes(extendedAttributeKeys []interface{}, protected c
 	}
 	var extendedAttr []signature.Attribute
 	for _, key := range extendedAttributeKeys {
-		_, ok1 := key.(string)
-		_, ok2 := key.(int)
-		if !ok1 && !ok2 {
-			return nil, &signature.InvalidSignatureError{Msg: "COSE extendedAttributes key requires string or int type"}
-		}
 		extendedAttr = append(extendedAttr, signature.Attribute{
 			Key:      key,
 			Critical: contains(criticalHeaders, key),

--- a/signature/cose/envelope.go
+++ b/signature/cose/envelope.go
@@ -551,19 +551,14 @@ func generateExtendedAttributes(extendedAttributeKeys []interface{}, protected c
 	}
 	var extendedAttr []signature.Attribute
 	for _, key := range extendedAttributeKeys {
-		isCritical := contains(criticalHeaders, key)
-		key, ok := key.(string)
-		if !ok {
-			// if marked as critical, keys are required of type string
-			if isCritical {
-				return nil, &signature.InvalidSignatureError{Msg: "critical extendedAttributes key requires string type"}
-			}
-			// if not marked as critical, non-string type keys are ignored
-			continue
+		_, ok1 := key.(string)
+		_, ok2 := key.(int)
+		if !ok1 && !ok2 {
+			return nil, &signature.InvalidSignatureError{Msg: "COSE extendedAttributes key requires string or int type"}
 		}
 		extendedAttr = append(extendedAttr, signature.Attribute{
 			Key:      key,
-			Critical: isCritical,
+			Critical: contains(criticalHeaders, key),
 			Value:    protected[key],
 		})
 	}

--- a/signature/cose/envelope_test.go
+++ b/signature/cose/envelope_test.go
@@ -499,33 +499,16 @@ func TestSignerInfoErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("when COSE envelope has customized critical protected header key that is not of string type", func(t *testing.T) {
+	t.Run("when COSE envelope has customized protected header key that is not of string or int type", func(t *testing.T) {
 		env, err := getVerifyCOSE("notary.x509", signature.KeyTypeRSA, 3072)
 		if err != nil {
 			t.Fatalf("getVerifyCOSE() failed. Error = %s", err)
 		}
-		env.base.Headers.Protected[0] = "unsupported"
-		crit, ok := env.base.Headers.Protected[cose.HeaderLabelCritical].([]interface{})
-		if !ok {
-			t.Fatalf("env.base.Headers.Protected[cose.HeaderLabelCritical] expects type []interface{}")
-		}
-		env.base.Headers.Protected[cose.HeaderLabelCritical] = append(crit, 0)
+		env.base.Headers.Protected[0.1] = "unsupported"
 		_, err = env.Content()
-		expected := errors.New("critical extendedAttributes key requires string type")
+		expected := errors.New("COSE extendedAttributes key requires string or int type")
 		if !isErrEqual(expected, err) {
 			t.Fatalf("Content() expects error: %v, but got: %v.", expected, err)
-		}
-	})
-
-	t.Run("when COSE envelope has customized non-critical protected header key that is not of string type", func(t *testing.T) {
-		env, err := getVerifyCOSE("notary.x509", signature.KeyTypeRSA, 3072)
-		if err != nil {
-			t.Fatalf("getVerifyCOSE() failed. Error = %s", err)
-		}
-		env.base.Headers.Protected[0] = "unsupported"
-		_, err = env.Content()
-		if !isErrEqual(nil, err) {
-			t.Fatalf("Content() expects error: %v, but got: %v.", nil, err)
 		}
 	})
 

--- a/signature/cose/envelope_test.go
+++ b/signature/cose/envelope_test.go
@@ -499,19 +499,6 @@ func TestSignerInfoErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("when COSE envelope has customized protected header key that is not of string or int type", func(t *testing.T) {
-		env, err := getVerifyCOSE("notary.x509", signature.KeyTypeRSA, 3072)
-		if err != nil {
-			t.Fatalf("getVerifyCOSE() failed. Error = %s", err)
-		}
-		env.base.Headers.Protected[0.1] = "unsupported"
-		_, err = env.Content()
-		expected := errors.New("COSE extendedAttributes key requires string or int type")
-		if !isErrEqual(expected, err) {
-			t.Fatalf("Content() expects error: %v, but got: %v.", expected, err)
-		}
-	})
-
 	t.Run("when COSE envelope protected header missing algorithm", func(t *testing.T) {
 		env, err := getVerifyCOSE("notary.x509", signature.KeyTypeRSA, 3072)
 		if err != nil {

--- a/signature/cose/envelope_test.go
+++ b/signature/cose/envelope_test.go
@@ -499,16 +499,33 @@ func TestSignerInfoErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("when COSE envelope has customized protected header key that is not of string type", func(t *testing.T) {
+	t.Run("when COSE envelope has customized critical protected header key that is not of string type", func(t *testing.T) {
+		env, err := getVerifyCOSE("notary.x509", signature.KeyTypeRSA, 3072)
+		if err != nil {
+			t.Fatalf("getVerifyCOSE() failed. Error = %s", err)
+		}
+		env.base.Headers.Protected[0] = "unsupported"
+		crit, ok := env.base.Headers.Protected[cose.HeaderLabelCritical].([]interface{})
+		if !ok {
+			t.Fatalf("env.base.Headers.Protected[cose.HeaderLabelCritical] expects type []interface{}")
+		}
+		env.base.Headers.Protected[cose.HeaderLabelCritical] = append(crit, 0)
+		_, err = env.Content()
+		expected := errors.New("critical extendedAttributes key requires string type")
+		if !isErrEqual(expected, err) {
+			t.Fatalf("Content() expects error: %v, but got: %v.", expected, err)
+		}
+	})
+
+	t.Run("when COSE envelope has customized non-critical protected header key that is not of string type", func(t *testing.T) {
 		env, err := getVerifyCOSE("notary.x509", signature.KeyTypeRSA, 3072)
 		if err != nil {
 			t.Fatalf("getVerifyCOSE() failed. Error = %s", err)
 		}
 		env.base.Headers.Protected[0] = "unsupported"
 		_, err = env.Content()
-		expected := errors.New("extendedAttributes key requires string type")
-		if !isErrEqual(expected, err) {
-			t.Fatalf("Content() expects error: %v, but got: %v.", expected, err)
+		if !isErrEqual(nil, err) {
+			t.Fatalf("Content() expects error: %v, but got: %v.", nil, err)
 		}
 	})
 

--- a/signature/jws/conformance_test.go
+++ b/signature/jws/conformance_test.go
@@ -177,7 +177,8 @@ func verifyAttributes(t *testing.T, signerInfo *signature.SignerInfo) {
 
 func sortAttributes(attributes []signature.Attribute) []signature.Attribute {
 	sort.Slice(attributes, func(i, j int) bool {
-		return strings.Compare(attributes[i].Key, attributes[j].Key) < 0
+		key1, key2 := attributes[i].Key.(string), attributes[j].Key.(string)
+		return strings.Compare(key1, key2) < 0
 	})
 	return attributes
 }

--- a/signature/jws/jws.go
+++ b/signature/jws/jws.go
@@ -189,9 +189,16 @@ func getSignedAttributes(req *signature.SignRequest, algorithm string) (map[stri
 
 	// write extended signed attributes to the extAttrs map
 	for _, elm := range req.ExtendedSignedAttributes {
-		extAttrs[elm.Key] = elm.Value
+		key, ok := elm.Key.(string)
+		if !ok {
+			return nil, &signature.InvalidSignRequestError{Msg: "JWS envelope format only supports key of type string"}
+		}
+		if _, ok := extAttrs[key]; ok {
+			return nil, &signature.InvalidSignRequestError{Msg: fmt.Sprintf("%q already exists in the extAttrs", key)}
+		}
+		extAttrs[key] = elm.Value
 		if elm.Critical {
-			crit = append(crit, elm.Key)
+			crit = append(crit, key)
 		}
 	}
 

--- a/signature/types.go
+++ b/signature/types.go
@@ -53,7 +53,7 @@ type UnsignedAttributes struct {
 // Attribute represents metadata in the Signature envelope.
 type Attribute struct {
 	// Key is the key name of the attribute.
-	Key string
+	Key interface{}
 
 	// Critical marks the attribute that MUST be processed by a verifier.
 	Critical bool


### PR DESCRIPTION
Fixed issue #88.

After this update:
1. JWS extended attribute keys still enforce string type.
2. COSE extended attribute keys will accept string and int type.

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>