### PR TITLE
update: enabled cose to verify time in Tag1 Datetime format

### DIFF
--- a/signature/cose/envelope_test.go
+++ b/signature/cose/envelope_test.go
@@ -558,7 +558,7 @@ func TestSignerInfoErrors(t *testing.T) {
 		}
 		env.base.Headers.Protected[headerLabelExpiry] = "invalid"
 		_, err = env.Content()
-		expected := errors.New("expiry requires int64 type")
+		expected := errors.New("invalid expiry")
 		if !isErrEqual(expected, err) {
 			t.Fatalf("Content() expects error: %v, but got: %v.", expected, err)
 		}

--- a/signature/internal/base/envelope.go
+++ b/signature/internal/base/envelope.go
@@ -114,7 +114,7 @@ func validateSignRequest(req *signature.SignRequest) error {
 	if _, err := req.Signer.KeySpec(); err != nil {
 		return err
 	}
-	
+
 	return validateSigningSchema(req.SigningScheme)
 }
 


### PR DESCRIPTION
This PR enables COSE to verify time in Tag1 Datetime format.

Sign (Encode/MarshalCBOR):
in go-cose, time.Time will be encoded as numerical (in integer) representation of seconds since January 1, 1970 UTC.
For more details: https://github.com/fxamacker/cbor/blob/7704fa5efaf3ef4ac35aff38f50f6ff567793072/encode.go#L75
                            https://github.com/veraison/go-cose/blob/f72b6bc06b90d1e9c07ab11332df92c7838e3027/cbor.go#L30

Verify (Decode/UnmarshalCBOR):
1. CBOR times (tag 0 and 1) decode to time.Time. (This applies to COSE signatures provided by PRSS/ESRP.)
2. decode CBOR uint/int to Go int64.  (This applies to signatures signed by Notation Sign. Although, user passes time.Time into signRequest in Notation Sign, after MarshalCBOR (during Sign) and UnmarshalCBOR (during Verify), this time.Time is actually converted to an int64 by go-cose.)
For more details: https://github.com/fxamacker/cbor/blob/7704fa5efaf3ef4ac35aff38f50f6ff567793072/decode.go#L52
                            https://github.com/veraison/go-cose/blob/f72b6bc06b90d1e9c07ab11332df92c7838e3027/cbor.go#L43

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>