### PR TITLE
timestamp: add fuzzer

### DIFF
--- a/timestamp/fuzz_test.go
+++ b/timestamp/fuzz_test.go
@@ -1,0 +1,11 @@
+package timestamp
+
+import (
+	"testing"
+)
+
+func FuzzParseSignedToken(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParseSignedToken(data)
+	})
+}


### PR DESCRIPTION
Adds a simple fuzzer for `FuzzParseSignedToken`.

Once merged, I will instruct OSS-Fuzz to run this fuzzer continuously.

Signed-off-by: AdamKorcz <adam@adalogics.com>