### PR TITLE
Add Pritesh Bandi as notation-core-go maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @priteshbandi

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)


### PR DESCRIPTION
Add Pritesh Bandi as a seed maintainer of notation-core-go based on [their](https://github.com/notaryproject/notation-core-go/commits?author=priteshbandi) activity as per - https://github.com/notaryproject/notation-core-go/issues/106

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>