### PR TITLE
Add Junjie Gao as notation-core-go maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JeyJeyGao

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Junjie Gao <junjiegao@microsoft.com> (@JeyJeyGao)


### PR DESCRIPTION
Add Junjie Gao (@JeyJeyGao) as a seed maintainer of `notation-core-go` based on [their](https://github.com/notaryproject/notation-core-go/commits?author=JeyJeyGao) activity as per - https://github.com/notaryproject/notation-core-go/issues/106

Signed-off-by: Yi Zha <yizha1@microsoft.com>