### PR TITLE
chore: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
@@ -39,14 +39,14 @@ body:
       required: true
     attributes:
       label: "How can we reproduce it?"
-      description: "Detailed steps to reproduce the behavior. Commands and their outputs are always helpful. If the bug is in a library, code snippets work as well."
+      description: "Detailed steps to reproduce the behavior. Commands and their outputs are always helpful, code snippets are welcome."
   - type: textarea
     id: environment
     validations:
       required: true
     attributes:
       label: Describe your environment 
-      description: "Notation installation method (e.g. wget, curl, brew, apt-get, yum, chocolate, MSI) if applicable / OS version / Shell type (e.g. zsh, bash, cmd.exe, Bash on Windows) / Golang version if applicable"
+      description: "OS and Golang version"
   - type: textarea
     id: version
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
@@ -57,4 +57,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        If you want to contribute to this project, we will be happy to guide you through out contribution process especially when you already have a good proposal or understanding of how to fix this issue. Join us at https://slack.cncf.io/ and choose #notary-project channel.
+        If you want to contribute to this project, we will be happy to guide you through the contribution process especially when you already have a good proposal or understanding of how to fix this issue. Join us at https://slack.cncf.io/ and choose #notary-project channel.

--- a/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
@@ -26,9 +26,7 @@ body:
     attributes:
       label: "What is the areas you experience the issue in?"
       options: 
-        - Notation CLI
         - Notation-Core-Go Library
-        - Notation-Go Library
   - type: textarea
     id: verbatim
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
@@ -1,0 +1,70 @@
+# Copyright The Notary Project Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 🐛 Bug or Issue
+description: Something is not working as expected or not working at all! Report it here!
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this issue report. 🛑 Please check existing issues first before continuing: https://github.com/notaryproject/notation/issues
+  - type: dropdown
+    id: area
+    validations:
+      required: true
+    attributes:
+      label: "What is the areas you experience the issue in?"
+      options: 
+        - Notation CLI
+        - Notation-Core-Go Library
+        - Notation-Go Library
+  - type: textarea
+    id: verbatim
+    validations:
+      required: true
+    attributes:
+      label: "What is not working as expected?"
+      description: "In your own words, describe what the issue is."
+  - type: textarea
+    id: expect
+    validations:
+      required: true
+    attributes:
+      label: "What did you expect to happen?"
+      description: "A clear and concise description of what you expected to happen."
+  - type: textarea
+    id: reproduce
+    validations:
+      required: true
+    attributes:
+      label: "How can we reproduce it?"
+      description: "Detailed steps to reproduce the behavior. Commands and their outputs are always helpful. If the bug is in a library, code snippets work as well."
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: Describe your environment 
+      description: "Notation installation method (e.g. wget, curl, brew, apt-get, yum, chocolate, MSI) if applicable / OS version / Shell type (e.g. zsh, bash, cmd.exe, Bash on Windows) / Golang version if applicable"
+  - type: textarea
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: What is the version of your Notation CLI or Notation Library?
+      description: "For the CLI, you can use the command `notation version` to get it. For the libraries check the `go.mod` file."
+  - type: markdown
+    attributes:
+      value: |
+        If you want to contribute to this project, we will be happy to guide you through out contribution process especially when you already have a good proposal or understanding of how to fix this issue. Join us at https://slack.cncf.io/ and choose #notary-project channel.

--- a/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-or-issue.yaml
@@ -18,15 +18,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to fill out this issue report. 🛑 Please check existing issues first before continuing: https://github.com/notaryproject/notation/issues
-  - type: dropdown
-    id: area
-    validations:
-      required: true
-    attributes:
-      label: "What is the areas you experience the issue in?"
-      options: 
-        - Notation-Core-Go Library
+        Thank you for taking the time to fill out this issue report. 🛑 Please check existing issues first before continuing: https://github.com/notaryproject/notation-core-go/issues
   - type: textarea
     id: verbatim
     validations:
@@ -60,8 +52,8 @@ body:
     validations:
       required: true
     attributes:
-      label: What is the version of your Notation CLI or Notation Library?
-      description: "For the CLI, you can use the command `notation version` to get it. For the libraries check the `go.mod` file."
+      label: What is the version of your notation-core-go Library?
+      description: "Check the `go.mod` file for the library version"
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,3 +15,4 @@ contact_links:
   - name: Ask a question
     url: https://slack.cncf.io/
     about: "Join #notary-project channel on CNCF Slack"
+    

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,4 +15,3 @@ contact_links:
   - name: Ask a question
     url: https://slack.cncf.io/
     about: "Join #notary-project channel on CNCF Slack"
-    

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# Copyright The Notary Project Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://slack.cncf.io/
+    about: "Join #notary-project channel on CNCF Slack"

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -50,4 +50,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        If you want to contribute to this project, we will be happy to guide you through out contribution process especially when you already have a good proposal or understanding of how to improve the functionality. Join us at https://slack.cncf.io/ and choose #notary-project channel.
+        If you want to contribute to this project, we will be happy to guide you through the contribution process especially when you already have a good proposal or understanding of how to improve the functionality. Join us at https://slack.cncf.io/ and choose #notary-project channel.

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,63 @@
+# Copyright The Notary Project Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 🚀 Feature Request
+description: Suggest an idea for this project.
+labels: [enhancement, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to suggest a useful feature for the project!
+  - type: dropdown
+    id: area
+    validations:
+      required: true
+    attributes:
+      label: "What is the areas you would like to add the new feature to?"
+      options: 
+        - Notation CLI
+        - Notation-Core-Go Library
+        - Notation-Go Library
+  - type: textarea
+    id: problem
+    validations:
+      required: true
+    attributes:
+      label: "Is your feature request related to a problem?"
+      description: "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+  - type: textarea
+    id: solution
+    validations:
+      required: true
+    attributes:
+      label: "What solution do you propose?"
+      description: "A clear and concise description of what you want to happen."
+  - type: textarea
+    id: alternatives
+    validations:
+      required: true
+    attributes:
+      label: "What alternatives have you considered?"
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+  - type: textarea
+    id: context
+    validations:
+      required: false
+    attributes:
+      label: "Any additional context?"
+      description: "Add any other context or screenshots about the feature request here."
+  - type: markdown
+    attributes:
+      value: |
+        If you want to contribute to this project, we will be happy to guide you through out contribution process especially when you already have a good proposal or understanding of how to improve the functionality. Join us at https://slack.cncf.io/ and choose #notary-project channel.

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -26,9 +26,7 @@ body:
     attributes:
       label: "What is the areas you would like to add the new feature to?"
       options: 
-        - Notation CLI
         - Notation-Core-Go Library
-        - Notation-Go Library
   - type: textarea
     id: problem
     validations:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -19,14 +19,6 @@ body:
     attributes:
       value: |
         Thank you for taking the time to suggest a useful feature for the project!
-  - type: dropdown
-    id: area
-    validations:
-      required: true
-    attributes:
-      label: "What is the areas you would like to add the new feature to?"
-      options: 
-        - Notation-Core-Go Library
   - type: textarea
     id: problem
     validations:


### PR DESCRIPTION
Add issue template for `notation-core-go`, which is copied from `notation` repo.

Signed-off-by: Yi Zha <yizha1@microsoft.com>