### PR TITLE
build: shift Go support window to [1.19, 1.20]

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19, 1.20]
+        go-version: [1.19, "1.20"]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18, 1.19]
+        go-version: [1.19, 1.20]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -13,7 +13,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: [1.19, 1.20]
+        go-version: [1.19, "1.20"]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -13,7 +13,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: [1.18, 1.19]
+        go-version: [1.19, 1.20]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/notaryproject/notation-core-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.0


### PR DESCRIPTION
Updates go.mod and the GitHub actions to shift window from [1.18, 1.19] to [1.19,1.20]

Confirmed that unit tests work for 1.20

Resolves #115 

Signed-off-by: Kody Kimberl kody.kimberl.work@gmail.com