### PR TITLE
fix: change OCSP hash and encoding

### DIFF
--- a/revocation/ocsp/ocsp.go
+++ b/revocation/ocsp/ocsp.go
@@ -167,7 +167,7 @@ func extensionsToMap(extensions []pkix.Extension) map[string][]byte {
 func executeOCSPCheck(cert, issuer *x509.Certificate, server string, opts Options) (*ocsp.Response, error) {
 	// TODO: Look into other alternatives for specifying the Hash
 	// https://github.com/notaryproject/notation-core-go/issues/139
-	ocspRequest, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{Hash: crypto.SHA256})
+	ocspRequest, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{Hash: crypto.SHA1})
 	if err != nil {
 		return nil, GenericError{Err: err}
 	}
@@ -177,7 +177,7 @@ func executeOCSPCheck(cert, issuer *x509.Certificate, server string, opts Option
 		reader := bytes.NewReader(ocspRequest)
 		resp, err = opts.HTTPClient.Post(server, "application/ocsp-request", reader)
 	} else {
-		encodedReq := base64.URLEncoding.EncodeToString(ocspRequest)
+		encodedReq := url.QueryEscape(base64.StdEncoding.EncodeToString(ocspRequest))
 		var reqURL string
 		reqURL, err = url.JoinPath(server, encodedReq)
 		if err != nil {

--- a/revocation/ocsp/ocsp.go
+++ b/revocation/ocsp/ocsp.go
@@ -185,18 +185,18 @@ func executeOCSPCheck(cert, issuer *x509.Certificate, server string, opts Option
 	var encodedReq string
 	if !postRequired {
 		encodedReq = url.QueryEscape(base64.StdEncoding.EncodeToString(ocspRequest))
-		postRequired = len(encodedReq) >= 255
-	}
-	if postRequired {
-		reader := bytes.NewReader(ocspRequest)
-		resp, err = opts.HTTPClient.Post(server, "application/ocsp-request", reader)
-	} else {
-		var reqURL string
-		reqURL, err = url.JoinPath(server, encodedReq)
-		if err != nil {
-			return nil, GenericError{Err: err}
+		if len(encodedReq) < 255 {
+			var reqURL string
+			reqURL, err = url.JoinPath(server, encodedReq)
+			if err != nil {
+				return nil, GenericError{Err: err}
+			}
+			resp, err = opts.HTTPClient.Get(reqURL)
+		} else {
+			resp, err = postRequest(ocspRequest, server, opts.HTTPClient)
 		}
-		resp, err = opts.HTTPClient.Get(reqURL)
+	} else {
+		resp, err = postRequest(ocspRequest, server, opts.HTTPClient)
 	}
 
 	if err != nil {
@@ -231,6 +231,11 @@ func executeOCSPCheck(cert, issuer *x509.Certificate, server string, opts Option
 	}
 
 	return ocsp.ParseResponseForCert(body, cert, issuer)
+}
+
+func postRequest(req []byte, server string, httpClient *http.Client) (*http.Response, error) {
+	reader := bytes.NewReader(req)
+	return httpClient.Post(server, "application/ocsp-request", reader)
 }
 
 func toServerResult(server string, err error) *result.ServerResult {

--- a/revocation/ocsp/ocsp.go
+++ b/revocation/ocsp/ocsp.go
@@ -182,9 +182,8 @@ func executeOCSPCheck(cert, issuer *x509.Certificate, server string, opts Option
 
 	var resp *http.Response
 	postRequired := base64.StdEncoding.EncodedLen(len(ocspRequest)) >= 255
-	var encodedReq string
 	if !postRequired {
-		encodedReq = url.QueryEscape(base64.StdEncoding.EncodeToString(ocspRequest))
+		encodedReq := url.QueryEscape(base64.StdEncoding.EncodeToString(ocspRequest))
 		if len(encodedReq) < 255 {
 			var reqURL string
 			reqURL, err = url.JoinPath(server, encodedReq)


### PR DESCRIPTION
This is a followup fix to #134 

After testing with real certificates, there are some discrepancies with what hashes are supported and the correct URL encoding.

---

The following do not support SHA256 hashes:
 - Microsoft
 - Entrust
 - Let's Encrypt
 - Digicert (sometimes)

As this represents a large percentage of public CAs, we should change the hashing algorithm to SHA1, which has been confirmed to be supported by all that were tested.

---

Additionally, the base64 URL encoding was not actually escaping URL characters, resulting in malformed requests. We need to change it to StdEncoding and query escape it.

Signed-off-by: Kody Kimberl kody.kimberl.work@gmail.com