### PR TITLE
build: shift Go support window to [1.20, 1.21]

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19, "1.20"]
+        go-version: ["1.20", "1.21"]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -26,7 +26,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: [1.19, "1.20"]
+        go-version: ["1.20", "1.21"]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/notaryproject/notation-core-go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.0


### PR DESCRIPTION
Since go has released 1.21, moving the build window from [1.19, "1.20"] to ["1.20", "1.21"].