### PR TITLE
fix: fix license dependency check workflow

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,9 +15,9 @@ name: License Checker
 
 on:
   push:
-    branches: main
-  pull_request:
-    branches: main
+  #   branches: main
+  # pull_request:
+  #   branches: main
 
 permissions:
   contents: write

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,9 +15,9 @@ name: License Checker
 
 on:
   push:
-  #   branches: main
-  # pull_request:
-  #   branches: main
+    branches: main
+  pull_request:
+    branches: main
 
 permissions:
   contents: write

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           config: .github/licenserc.yml
           flags:
-            --compatible-with-conditions=true
+            --weak-compatible=true

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           config: .github/licenserc.yml
           flags:
-            --compatible-with-conditions=true
+            

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check license header
-        uses: apache/skywalking-eyes/header@v0.4.0
+        uses: Two-Hearts/skywalking-eyes/header@v0.5.0
         with:
           mode: check
           config: .github/licenserc.yml
       - name: Check dependencies license
-        uses: apache/skywalking-eyes/dependency@v0.4.0
+        uses: Two-Hearts/skywalking-eyes/dependency@v0.5.0
         with:
           config: .github/licenserc.yml

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -31,3 +31,5 @@ jobs:
         uses: Two-Hearts/skywalking-eyes/dependency@compatible-with-conditions
         with:
           config: .github/licenserc.yml
+          flags:
+            --compatible-with-conditions=true

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check license header
-        uses: Two-Hearts/skywalking-eyes/header@a790ab8dd23a7f861c18bd6aaa9b012e3a234bce
+        uses: apache/skywalking-eyes/header@a790ab8dd23a7f861c18bd6aaa9b012e3a234bce
 
         with:
           mode: check
           config: .github/licenserc.yml
       - name: Check dependencies license
-        uses: Two-Hearts/skywalking-eyes/dependency@a790ab8dd23a7f861c18bd6aaa9b012e3a234bce
+        uses: apache/skywalking-eyes/dependency@a790ab8dd23a7f861c18bd6aaa9b012e3a234bce
         with:
           config: .github/licenserc.yml
           flags:

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           config: .github/licenserc.yml
           flags:
-            
+            --compatible-with-conditions=true

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check license header
-        uses: Two-Hearts/skywalking-eyes/header@v0.5.0
+        uses: Two-Hearts/skywalking-eyes/header@main
         with:
           mode: check
           config: .github/licenserc.yml
       - name: Check dependencies license
-        uses: Two-Hearts/skywalking-eyes/dependency@v0.5.0
+        uses: Two-Hearts/skywalking-eyes/dependency@main
         with:
           config: .github/licenserc.yml

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check license header
-        uses: Two-Hearts/skywalking-eyes/header@main
+        uses: Two-Hearts/skywalking-eyes/header@compatible-with-conditions
         with:
           mode: check
           config: .github/licenserc.yml
       - name: Check dependencies license
-        uses: Two-Hearts/skywalking-eyes/dependency@main
+        uses: Two-Hearts/skywalking-eyes/dependency@compatible-with-conditions
         with:
           config: .github/licenserc.yml

--- a/.github/workflows/reusable-license-checker.yml
+++ b/.github/workflows/reusable-license-checker.yml
@@ -23,12 +23,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check license header
-        uses: Two-Hearts/skywalking-eyes/header@compatible-with-conditions
+        uses: Two-Hearts/skywalking-eyes/header@a790ab8dd23a7f861c18bd6aaa9b012e3a234bce
+
         with:
           mode: check
           config: .github/licenserc.yml
       - name: Check dependencies license
-        uses: Two-Hearts/skywalking-eyes/dependency@compatible-with-conditions
+        uses: Two-Hearts/skywalking-eyes/dependency@a790ab8dd23a7f861c18bd6aaa9b012e3a234bce
         with:
           config: .github/licenserc.yml
           flags:


### PR DESCRIPTION
This PR updates license-checker to the fixed version of skywalking-eyes.

The related discussion: https://github.com/apache/skywalking/discussions/11391