### PR TITLE
fix(ci): pass CODECOV_TOKEN to reusable-build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,5 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/reusable-build.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -15,6 +15,9 @@ name: Reusable build
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   build:


### PR DESCRIPTION
Fix:
- All the `main` branch build are failed at the step to upload codecov because of lacking of codecov token: https://github.com/notaryproject/notation-core-go/actions/runs/9706110222/job/26789276954#step:5:32
- manually pass CODECOV_TOKEN to reusable-build.yml

Reference: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

Will update notation-go, tsp-client after this PR is merged.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>