### PR TITLE
fix: fix `signerInfo.authenticSigningTime` according to spec

### DIFF
--- a/signature/types.go
+++ b/signature/types.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/notaryproject/tspclient-go"
@@ -197,17 +198,17 @@ func (signerInfo *SignerInfo) ExtendedAttribute(key string) (Attribute, error) {
 	return Attribute{}, errors.New("key not in ExtendedAttributes")
 }
 
-// AuthenticSigningTime returns the authentic signing time
+// AuthenticSigningTime returns the authentic signing time under signing scheme
+// notary.x509.signingAuthority.
+// For signing scheme notary.x509, since it only supports authentic timestamp,
+// an error is returned.
+//
+// Reference: https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#signing-time--authentic-signing-time
 func (signerInfo *SignerInfo) AuthenticSigningTime() (time.Time, error) {
-	switch signerInfo.SignedAttributes.SigningScheme {
-	case SigningSchemeX509SigningAuthority:
+	switch signingScheme := signerInfo.SignedAttributes.SigningScheme; {
+	case signingScheme == SigningSchemeX509SigningAuthority:
 		return signerInfo.SignedAttributes.SigningTime, nil
-	case SigningSchemeX509:
-		if len(signerInfo.UnsignedAttributes.TimestampSignature) > 0 {
-			// TODO: Add TSA support for AutheticSigningTime
-			// https://github.com/notaryproject/notation-core-go/issues/38
-			return time.Time{}, errors.New("TSA checking has not been implemented")
-		}
+	default:
+		return time.Time{}, fmt.Errorf("authenticSigningTime not supported under signing scheme %q", signingScheme)
 	}
-	return time.Time{}, errors.New("authenticSigningTime not found")
 }

--- a/signature/types.go
+++ b/signature/types.go
@@ -203,14 +203,15 @@ func (signerInfo *SignerInfo) ExtendedAttribute(key string) (Attribute, error) {
 // For signing scheme notary.x509, since it only supports authentic timestamp,
 // an error is returned.
 //
-// Reference: https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#signing-time--authentic-signing-time
+// Reference: https://github.com/notaryproject/specifications/blob/3b0743cd9bb99faee60600dc31d706149775fd49/specs/signature-specification.md#signing-time--authentic-signing-time
 func (signerInfo *SignerInfo) AuthenticSigningTime() (time.Time, error) {
-	switch signingScheme := signerInfo.SignedAttributes.SigningScheme; {
-	case signingScheme == SigningSchemeX509SigningAuthority:
-		if signerInfo.SignedAttributes.SigningTime.IsZero() {
+	switch signingScheme := signerInfo.SignedAttributes.SigningScheme; signingScheme {
+	case SigningSchemeX509SigningAuthority:
+		signingTime := signerInfo.SignedAttributes.SigningTime
+		if signingTime.IsZero() {
 			return time.Time{}, fmt.Errorf("authentic signing time must be present under signing scheme %q", signingScheme)
 		}
-		return signerInfo.SignedAttributes.SigningTime, nil
+		return signingTime, nil
 	default:
 		return time.Time{}, fmt.Errorf("authentic signing time not supported under signing scheme %q", signingScheme)
 	}

--- a/signature/types.go
+++ b/signature/types.go
@@ -207,8 +207,11 @@ func (signerInfo *SignerInfo) ExtendedAttribute(key string) (Attribute, error) {
 func (signerInfo *SignerInfo) AuthenticSigningTime() (time.Time, error) {
 	switch signingScheme := signerInfo.SignedAttributes.SigningScheme; {
 	case signingScheme == SigningSchemeX509SigningAuthority:
+		if signerInfo.SignedAttributes.SigningTime.IsZero() {
+			return time.Time{}, fmt.Errorf("authentic signing time must be present under signing scheme %q", signingScheme)
+		}
 		return signerInfo.SignedAttributes.SigningTime, nil
 	default:
-		return time.Time{}, fmt.Errorf("authenticSigningTime not supported under signing scheme %q", signingScheme)
+		return time.Time{}, fmt.Errorf("authentic signing time not supported under signing scheme %q", signingScheme)
 	}
 }

--- a/signature/types_test.go
+++ b/signature/types_test.go
@@ -71,10 +71,21 @@ func TestAuthenticSigningTime(t *testing.T) {
 
 	signerInfo = SignerInfo{
 		SignedAttributes: SignedAttributes{
+			SigningScheme: "notary.x509.signingAuthority",
+		},
+	}
+	expectedErrMsg := "authentic signing time must be present under signing scheme \"notary.x509.signingAuthority\""
+	_, err = signerInfo.AuthenticSigningTime()
+	if err == nil || err.Error() != expectedErrMsg {
+		t.Fatalf("expected %s, but got %s", expectedErrMsg, err)
+	}
+
+	signerInfo = SignerInfo{
+		SignedAttributes: SignedAttributes{
 			SigningScheme: "notary.x509",
 		},
 	}
-	expectedErrMsg := "authenticSigningTime not supported under signing scheme \"notary.x509\""
+	expectedErrMsg = "authentic signing time not supported under signing scheme \"notary.x509\""
 	_, err = signerInfo.AuthenticSigningTime()
 	if err == nil || err.Error() != expectedErrMsg {
 		t.Fatalf("expected %s, but got %s", expectedErrMsg, err)


### PR DESCRIPTION
This PR fixes `signerInfo.AuthenticSigningTime` to return the correct results. 

According to spec: https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#signing-time--authentic-signing-time: 
`authentic signing time` is a valid concept only under signing scheme [`notary.x509.signingAuthority`](https://github.com/notaryproject/specifications/blob/main/specs/signing-scheme.md/#notaryx509signingauthority). Therefore, for other signing schemes, this function should return an error.

Resolves #38 