### PR TITLE
test(signature): add two fuzz tests

### DIFF
--- a/signature/cose/fuzz_test.go
+++ b/signature/cose/fuzz_test.go
@@ -1,0 +1,33 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cose
+
+import (
+	"testing"
+)
+
+func FuzzSignatureCose(f *testing.F) {
+	f.Fuzz(func(t *testing.T, envelopeBytes []byte, shouldVerify bool) {
+		e, err := ParseEnvelope(envelopeBytes)
+		if err != nil {
+			t.Skip()
+		}
+
+		if shouldVerify {
+			_, _ = e.Verify()
+		} else {
+			_, _ = e.Content()
+		}
+	})
+}

--- a/signature/jws/fuzz_test.go
+++ b/signature/jws/fuzz_test.go
@@ -1,0 +1,33 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jws
+
+import (
+	"testing"
+)
+
+func FuzzSignatureJws(f *testing.F) {
+	f.Fuzz(func(t *testing.T, envelopeBytes []byte, shouldVerify bool) {
+		e, err := ParseEnvelope(envelopeBytes)
+		if err != nil {
+			t.Skip()
+		}
+
+		if shouldVerify {
+			_, _ = e.Verify()
+		} else {
+			_, _ = e.Content()
+		}
+	})
+}


### PR DESCRIPTION
Moves two fuzz tests upstream from here:

1. https://github.com/cncf/cncf-fuzzing/blob/main/projects/notary/fuzz_cose.go
2. https://github.com/cncf/cncf-fuzzing/blob/main/projects/notary/fuzz_jws.go