### PR TITLE
chore: adding constants defined by notary project spec

### DIFF
--- a/signature/types.go
+++ b/signature/types.go
@@ -23,14 +23,6 @@ import (
 	"github.com/notaryproject/tspclient-go"
 )
 
-// SignatureMediaType list the supported media-type for signatures.
-type SignatureMediaType string
-
-// SigningScheme formalizes the feature set (guarantees) provided by
-// the signature.
-// Reference: https://github.com/notaryproject/notaryproject/blob/main/specs/signing-scheme.md
-type SigningScheme string
-
 // Constants supported by notation signature.
 const (
 	// MediaTypePayloadV1 is the supported content type for signature's payload.
@@ -42,6 +34,14 @@ const (
 	// Reference: https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#signature
 	AnnotationX509ChainThumbprint = "io.cncf.notary.x509chain.thumbprint#S256"
 )
+
+// SignatureMediaType list the supported media-type for signatures.
+type SignatureMediaType string
+
+// SigningScheme formalizes the feature set (guarantees) provided by
+// the signature.
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/specs/signing-scheme.md
+type SigningScheme string
 
 // SigningSchemes supported by notation.
 const (

--- a/signature/types.go
+++ b/signature/types.go
@@ -31,6 +31,18 @@ type SignatureMediaType string
 // Reference: https://github.com/notaryproject/notaryproject/blob/main/specs/signing-scheme.md
 type SigningScheme string
 
+// Constants supported by notation signature.
+const (
+	// MediaTypePayloadV1 is the supported content type for signature's payload.
+	// Reference: https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#payload
+	MediaTypePayloadV1 = "application/vnd.cncf.notary.payload.v1+json"
+
+	// AnnotationX509ChainThumbprint contains the list of SHA-256 fingerprints
+	// of signing certificate and certificate chain.
+	// Reference: https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#signature
+	AnnotationX509ChainThumbprint = "io.cncf.notary.x509chain.thumbprint#S256"
+)
+
 // SigningSchemes supported by notation.
 const (
 	// notary.x509 signing scheme.


### PR DESCRIPTION
Adding constants `MediaTypePayloadV1` and `AnnotationX509ChainThumbprint` to the library as they are defined by notary project spec.

They should be put at `types.go` of notation-core-go along with other types defined by the spec.

Related issue: https://github.com/notaryproject/notation-go/issues/398.