### PR TITLE
fix: ocsp revocation check with context

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -15,4 +15,7 @@ coverage:
   status:
     project:
       default:
-        target: 89% 
+        target: 89%
+    patch:
+      default:
+        target: 89%

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -18,4 +18,4 @@ coverage:
         target: 89%
     patch:
       default:
-        target: 89%
+        target: 90%

--- a/revocation/internal/ocsp/ocsp.go
+++ b/revocation/internal/ocsp/ocsp.go
@@ -170,7 +170,7 @@ func executeOCSPCheck(ctx context.Context, cert, issuer *x509.Certificate, serve
 				return nil, GenericError{Err: err}
 			}
 			var httpReq *http.Request
-			httpReq, err = http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+			httpReq, err = http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -219,7 +219,7 @@ func executeOCSPCheck(ctx context.Context, cert, issuer *x509.Certificate, serve
 }
 
 func postRequest(ctx context.Context, req []byte, server string, httpClient *http.Client) (*http.Response, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", server, bytes.NewReader(req))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, server, bytes.NewReader(req))
 	if err != nil {
 		return nil, err
 	}

--- a/revocation/internal/ocsp/ocsp_test.go
+++ b/revocation/internal/ocsp/ocsp_test.go
@@ -223,14 +223,23 @@ func TestCheckStatusFromServer(t *testing.T) {
 }
 
 func TestPostRequest(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("failed to execute request", func(t *testing.T) {
-		_, err := postRequest(ctx, nil, "http://example.com", &http.Client{
+	t.Run("failed to generate request", func(t *testing.T) {
+		_, err := postRequest(nil, nil, "http://example.com", &http.Client{
 			Transport: &failedTransport{},
 		})
-		if err == nil {
-			t.Errorf("Expected error, but got nil")
+		expectedErrMsg := "net/http: nil Context"
+		if err == nil || err.Error() != expectedErrMsg {
+			t.Errorf("Expected error %s, but got %s", expectedErrMsg, err)
+		}
+	})
+
+	t.Run("failed to execute request", func(t *testing.T) {
+		_, err := postRequest(context.Background(), nil, "http://example.com", &http.Client{
+			Transport: &failedTransport{},
+		})
+		expectedErrMsg := "Post \"http://example.com\": failed to execute request"
+		if err == nil || err.Error() != expectedErrMsg {
+			t.Errorf("Expected error %s, but got %s", expectedErrMsg, err)
 		}
 	})
 }

--- a/revocation/ocsp/ocsp.go
+++ b/revocation/ocsp/ocsp.go
@@ -16,6 +16,7 @@
 package ocsp
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"net/http"
@@ -66,7 +67,7 @@ func CheckStatus(opts Options) ([]*result.CertRevocationResult, error) {
 		// Assume cert chain is accurate and next cert in chain is the issuer
 		go func(i int, cert *x509.Certificate) {
 			defer wg.Done()
-			certResults[i] = ocsp.CertCheckStatus(cert, opts.CertChain[i+1], certCheckStatusOptions)
+			certResults[i] = ocsp.CertCheckStatus(context.Background(), cert, opts.CertChain[i+1], certCheckStatusOptions)
 		}(i, cert)
 	}
 	// Last is root cert, which will never be revoked by OCSP

--- a/revocation/ocsp/ocsp.go
+++ b/revocation/ocsp/ocsp.go
@@ -62,12 +62,13 @@ func CheckStatus(opts Options) ([]*result.CertRevocationResult, error) {
 
 	// Check status for each cert in cert chain
 	var wg sync.WaitGroup
+	ctx := context.Background()
 	for i, cert := range opts.CertChain[:len(opts.CertChain)-1] {
 		wg.Add(1)
 		// Assume cert chain is accurate and next cert in chain is the issuer
 		go func(i int, cert *x509.Certificate) {
 			defer wg.Done()
-			certResults[i] = ocsp.CertCheckStatus(context.Background(), cert, opts.CertChain[i+1], certCheckStatusOptions)
+			certResults[i] = ocsp.CertCheckStatus(ctx, cert, opts.CertChain[i+1], certCheckStatusOptions)
 		}(i, cert)
 	}
 	// Last is root cert, which will never be revoked by OCSP

--- a/revocation/revocation.go
+++ b/revocation/revocation.go
@@ -209,7 +209,7 @@ func (r *revocation) ValidateContext(ctx context.Context, validateContextOpts Va
 					}
 				}()
 
-				ocspResult := ocsp.CertCheckStatus(cert, certChain[i+1], ocspOpts)
+				ocspResult := ocsp.CertCheckStatus(ctx, cert, certChain[i+1], ocspOpts)
 				if ocspResult != nil && ocspResult.Result == result.ResultUnknown && crl.Supported(cert) {
 					// try CRL check if OCSP serverResult is unknown
 					serverResult := crl.CertCheckStatus(ctx, cert, certChain[i+1], crlOpts)


### PR DESCRIPTION
This PR adds `context` to OCSP revocation check.

Resolves #223 