### PR TITLE
fix(test): test cases with `example.com` URL

### DIFF
--- a/revocation/crl/fetcher_test.go
+++ b/revocation/crl/fetcher_test.go
@@ -55,7 +55,7 @@ func TestFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse base CRL: %v", err)
 	}
-	const exampleURL = "http://example.fake"
+	const exampleURL = "http://localhost.test"
 	const uncachedURL = "http://uncached.com"
 
 	bundle := &Bundle{
@@ -167,7 +167,7 @@ func TestFetch(t *testing.T) {
 			t.Fatalf("failed to parse base CRL: %v", err)
 		}
 		// store the expired CRL
-		const expiredCRLURL = "http://example.fake/expired"
+		const expiredCRLURL = "http://localhost.test/expired"
 		bundle := &Bundle{
 			BaseCRL: expiredCRL,
 		}
@@ -299,7 +299,7 @@ func TestDownload(t *testing.T) {
 		}
 	})
 	t.Run("https download", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "https://example.fake", http.DefaultClient)
+		_, err := fetchCRL(context.Background(), "https://localhost.test", http.DefaultClient)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -307,14 +307,14 @@ func TestDownload(t *testing.T) {
 
 	t.Run("http.NewRequestWithContext error", func(t *testing.T) {
 		var ctx context.Context = nil
-		_, err := fetchCRL(ctx, "http://example.fake", &http.Client{})
+		_, err := fetchCRL(ctx, "http://localhost.test", &http.Client{})
 		if err == nil {
 			t.Fatal("expected error")
 		}
 	})
 
 	t.Run("client.Do error", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://localhost.test", &http.Client{
 			Transport: errorRoundTripperMock{},
 		})
 
@@ -324,7 +324,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("status code is not 2xx", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://localhost.test", &http.Client{
 			Transport: serverErrorRoundTripperMock{},
 		})
 		if err == nil {
@@ -333,7 +333,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("readAll error", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://localhost.test", &http.Client{
 			Transport: readFailedRoundTripperMock{},
 		})
 		if err == nil {
@@ -342,7 +342,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("exceed the size limit", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://localhost.test", &http.Client{
 			Transport: expectedRoundTripperMock{Body: make([]byte, maxCRLSize+1)},
 		})
 		if err == nil {
@@ -351,7 +351,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("invalid crl", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://localhost.test", &http.Client{
 			Transport: expectedRoundTripperMock{Body: []byte("invalid crl")},
 		})
 		if err == nil {

--- a/revocation/crl/fetcher_test.go
+++ b/revocation/crl/fetcher_test.go
@@ -55,7 +55,7 @@ func TestFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse base CRL: %v", err)
 	}
-	const exampleURL = "http://example.com"
+	const exampleURL = "http://example.fake"
 	const uncachedURL = "http://uncached.com"
 
 	bundle := &Bundle{
@@ -167,7 +167,7 @@ func TestFetch(t *testing.T) {
 			t.Fatalf("failed to parse base CRL: %v", err)
 		}
 		// store the expired CRL
-		const expiredCRLURL = "http://example.com/expired"
+		const expiredCRLURL = "http://example.fake/expired"
 		bundle := &Bundle{
 			BaseCRL: expiredCRL,
 		}
@@ -299,7 +299,7 @@ func TestDownload(t *testing.T) {
 		}
 	})
 	t.Run("https download", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "https://example.com", http.DefaultClient)
+		_, err := fetchCRL(context.Background(), "https://example.fake", http.DefaultClient)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -307,14 +307,14 @@ func TestDownload(t *testing.T) {
 
 	t.Run("http.NewRequestWithContext error", func(t *testing.T) {
 		var ctx context.Context = nil
-		_, err := fetchCRL(ctx, "http://example.com", &http.Client{})
+		_, err := fetchCRL(ctx, "http://example.fake", &http.Client{})
 		if err == nil {
 			t.Fatal("expected error")
 		}
 	})
 
 	t.Run("client.Do error", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.com", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
 			Transport: errorRoundTripperMock{},
 		})
 
@@ -324,7 +324,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("status code is not 2xx", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.com", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
 			Transport: serverErrorRoundTripperMock{},
 		})
 		if err == nil {
@@ -333,7 +333,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("readAll error", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.com", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
 			Transport: readFailedRoundTripperMock{},
 		})
 		if err == nil {
@@ -342,7 +342,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("exceed the size limit", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.com", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
 			Transport: expectedRoundTripperMock{Body: make([]byte, maxCRLSize+1)},
 		})
 		if err == nil {
@@ -351,7 +351,7 @@ func TestDownload(t *testing.T) {
 	})
 
 	t.Run("invalid crl", func(t *testing.T) {
-		_, err := fetchCRL(context.Background(), "http://example.com", &http.Client{
+		_, err := fetchCRL(context.Background(), "http://example.fake", &http.Client{
 			Transport: expectedRoundTripperMock{Body: []byte("invalid crl")},
 		})
 		if err == nil {

--- a/revocation/crl/fetcher_test.go
+++ b/revocation/crl/fetcher_test.go
@@ -56,7 +56,7 @@ func TestFetch(t *testing.T) {
 		t.Fatalf("failed to parse base CRL: %v", err)
 	}
 	const exampleURL = "http://localhost.test"
-	const uncachedURL = "http://uncached.com"
+	const uncachedURL = "http://uncached.test"
 
 	bundle := &Bundle{
 		BaseCRL: baseCRL,

--- a/revocation/internal/crl/crl_test.go
+++ b/revocation/internal/crl/crl_test.go
@@ -45,7 +45,7 @@ func TestCertCheckStatus(t *testing.T) {
 
 	t.Run("fetcher is nil", func(t *testing.T) {
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.com"},
+			CRLDistributionPoints: []string{"http://example.fake"},
 		}
 		r := CertCheckStatus(context.Background(), cert, &x509.Certificate{}, CertCheckStatusOptions{})
 		if r.ServerResults[0].Error.Error() != "CRL fetcher cannot be nil" {
@@ -57,7 +57,7 @@ func TestCertCheckStatus(t *testing.T) {
 		memoryCache := &memoryCache{}
 
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.com"},
+			CRLDistributionPoints: []string{"http://example.fake"},
 		}
 		fetcher, err := crlutils.NewHTTPFetcher(
 			&http.Client{Transport: errorRoundTripperMock{}},
@@ -80,7 +80,7 @@ func TestCertCheckStatus(t *testing.T) {
 		memoryCache := &memoryCache{}
 
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.com"},
+			CRLDistributionPoints: []string{"http://example.fake"},
 		}
 		fetcher, err := crlutils.NewHTTPFetcher(
 			&http.Client{Transport: expiredCRLRoundTripperMock{}},
@@ -253,11 +253,11 @@ func TestCertCheckStatus(t *testing.T) {
 		BaseCRL: base,
 	}
 
-	chain[0].Cert.CRLDistributionPoints = []string{"http://example.com"}
+	chain[0].Cert.CRLDistributionPoints = []string{"http://example.fake"}
 
 	t.Run("invalid stale CRL cache, and re-download failed", func(t *testing.T) {
 		// save to cache
-		if err := memoryCache.Set(context.Background(), "http://example.com", bundle); err != nil {
+		if err := memoryCache.Set(context.Background(), "http://example.fake", bundle); err != nil {
 			t.Fatal(err)
 		}
 
@@ -279,7 +279,7 @@ func TestCertCheckStatus(t *testing.T) {
 
 	t.Run("invalid stale CRL cache, re-download and still validate failed", func(t *testing.T) {
 		// save to cache
-		if err := memoryCache.Set(context.Background(), "http://example.com", bundle); err != nil {
+		if err := memoryCache.Set(context.Background(), "http://example.fake", bundle); err != nil {
 			t.Fatal(err)
 		}
 
@@ -301,7 +301,7 @@ func TestCertCheckStatus(t *testing.T) {
 
 	t.Run("invalid stale CRL cache, re-download and validate seccessfully", func(t *testing.T) {
 		// save to cache
-		if err := memoryCache.Set(context.Background(), "http://example.com", bundle); err != nil {
+		if err := memoryCache.Set(context.Background(), "http://example.fake", bundle); err != nil {
 			t.Fatal(err)
 		}
 
@@ -722,7 +722,7 @@ func marshalGeneralizedTimeToBytes(t time.Time) ([]byte, error) {
 func TestSupported(t *testing.T) {
 	t.Run("supported", func(t *testing.T) {
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.com"},
+			CRLDistributionPoints: []string{"http://example.fake"},
 		}
 		if !Supported(cert) {
 			t.Fatal("expected supported")

--- a/revocation/internal/crl/crl_test.go
+++ b/revocation/internal/crl/crl_test.go
@@ -45,7 +45,7 @@ func TestCertCheckStatus(t *testing.T) {
 
 	t.Run("fetcher is nil", func(t *testing.T) {
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.fake"},
+			CRLDistributionPoints: []string{"http://localhost.test"},
 		}
 		r := CertCheckStatus(context.Background(), cert, &x509.Certificate{}, CertCheckStatusOptions{})
 		if r.ServerResults[0].Error.Error() != "CRL fetcher cannot be nil" {
@@ -57,7 +57,7 @@ func TestCertCheckStatus(t *testing.T) {
 		memoryCache := &memoryCache{}
 
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.fake"},
+			CRLDistributionPoints: []string{"http://localhost.test"},
 		}
 		fetcher, err := crlutils.NewHTTPFetcher(
 			&http.Client{Transport: errorRoundTripperMock{}},
@@ -80,7 +80,7 @@ func TestCertCheckStatus(t *testing.T) {
 		memoryCache := &memoryCache{}
 
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.fake"},
+			CRLDistributionPoints: []string{"http://localhost.test"},
 		}
 		fetcher, err := crlutils.NewHTTPFetcher(
 			&http.Client{Transport: expiredCRLRoundTripperMock{}},
@@ -253,11 +253,11 @@ func TestCertCheckStatus(t *testing.T) {
 		BaseCRL: base,
 	}
 
-	chain[0].Cert.CRLDistributionPoints = []string{"http://example.fake"}
+	chain[0].Cert.CRLDistributionPoints = []string{"http://localhost.test"}
 
 	t.Run("invalid stale CRL cache, and re-download failed", func(t *testing.T) {
 		// save to cache
-		if err := memoryCache.Set(context.Background(), "http://example.fake", bundle); err != nil {
+		if err := memoryCache.Set(context.Background(), "http://localhost.test", bundle); err != nil {
 			t.Fatal(err)
 		}
 
@@ -279,7 +279,7 @@ func TestCertCheckStatus(t *testing.T) {
 
 	t.Run("invalid stale CRL cache, re-download and still validate failed", func(t *testing.T) {
 		// save to cache
-		if err := memoryCache.Set(context.Background(), "http://example.fake", bundle); err != nil {
+		if err := memoryCache.Set(context.Background(), "http://localhost.test", bundle); err != nil {
 			t.Fatal(err)
 		}
 
@@ -301,7 +301,7 @@ func TestCertCheckStatus(t *testing.T) {
 
 	t.Run("invalid stale CRL cache, re-download and validate seccessfully", func(t *testing.T) {
 		// save to cache
-		if err := memoryCache.Set(context.Background(), "http://example.fake", bundle); err != nil {
+		if err := memoryCache.Set(context.Background(), "http://localhost.test", bundle); err != nil {
 			t.Fatal(err)
 		}
 
@@ -722,7 +722,7 @@ func marshalGeneralizedTimeToBytes(t time.Time) ([]byte, error) {
 func TestSupported(t *testing.T) {
 	t.Run("supported", func(t *testing.T) {
 		cert := &x509.Certificate{
-			CRLDistributionPoints: []string{"http://example.fake"},
+			CRLDistributionPoints: []string{"http://localhost.test"},
 		}
 		if !Supported(cert) {
 			t.Fatal("expected supported")

--- a/revocation/internal/ocsp/ocsp_test.go
+++ b/revocation/internal/ocsp/ocsp_test.go
@@ -152,7 +152,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("server url is not http", func(t *testing.T) {
-		server := "https://example.fake"
+		server := "https://localhost.test"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{})
 		expectedResult := toServerResult(server, GenericError{Err: fmt.Errorf("OCSPServer protocol %s is not supported", "https")})
 		if serverResult.Result != expectedResult.Result {
@@ -169,7 +169,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	})
 
 	t.Run("request error", func(t *testing.T) {
-		server := "http://example.fake"
+		server := "http://localhost.test"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: &http.Client{
 				Transport: &failedTransport{},
@@ -183,7 +183,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 	t.Run("ocsp expired", func(t *testing.T) {
 		client := testhelper.MockClient([]testhelper.RSACertTuple{revokableCertTuple, revokableIssuerTuple}, []ocsp.ResponseStatus{ocsp.Good}, nil, true)
-		server := "http://example.fake/expired_ocsp"
+		server := "http://localhost.test/expired_ocsp"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: client,
 		})
@@ -195,7 +195,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 	t.Run("ocsp request roundtrip failed", func(t *testing.T) {
 		client := testhelper.MockClient([]testhelper.RSACertTuple{revokableCertTuple, revokableIssuerTuple}, []ocsp.ResponseStatus{ocsp.Good}, nil, true)
-		server := "http://example.fake"
+		server := "http://localhost.test"
 		serverResult := checkStatusFromServer(nil, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: client,
 		})
@@ -206,7 +206,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	})
 
 	t.Run("ocsp request roundtrip timeout", func(t *testing.T) {
-		server := "http://example.fake"
+		server := "http://localhost.test"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: &http.Client{
 				Timeout: 1 * time.Second,
@@ -224,7 +224,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 func TestPostRequest(t *testing.T) {
 	t.Run("failed to generate request", func(t *testing.T) {
-		_, err := postRequest(nil, nil, "http://example.fake", &http.Client{
+		_, err := postRequest(nil, nil, "http://localhost.test", &http.Client{
 			Transport: &failedTransport{},
 		})
 		expectedErrMsg := "net/http: nil Context"
@@ -234,10 +234,10 @@ func TestPostRequest(t *testing.T) {
 	})
 
 	t.Run("failed to execute request", func(t *testing.T) {
-		_, err := postRequest(context.Background(), nil, "http://example.fake", &http.Client{
+		_, err := postRequest(context.Background(), nil, "http://localhost.test", &http.Client{
 			Transport: &failedTransport{},
 		})
-		expectedErrMsg := "Post \"http://example.fake\": failed to execute request"
+		expectedErrMsg := "Post \"http://localhost.test\": failed to execute request"
 		if err == nil || err.Error() != expectedErrMsg {
 			t.Errorf("Expected error %s, but got %s", expectedErrMsg, err)
 		}

--- a/revocation/internal/ocsp/ocsp_test.go
+++ b/revocation/internal/ocsp/ocsp_test.go
@@ -152,7 +152,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("server url is not http", func(t *testing.T) {
-		server := "https://example.com"
+		server := "https://example.fake"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{})
 		expectedResult := toServerResult(server, GenericError{Err: fmt.Errorf("OCSPServer protocol %s is not supported", "https")})
 		if serverResult.Result != expectedResult.Result {
@@ -169,7 +169,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	})
 
 	t.Run("request error", func(t *testing.T) {
-		server := "http://example.com"
+		server := "http://example.fake"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: &http.Client{
 				Transport: &failedTransport{},
@@ -183,7 +183,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 	t.Run("ocsp expired", func(t *testing.T) {
 		client := testhelper.MockClient([]testhelper.RSACertTuple{revokableCertTuple, revokableIssuerTuple}, []ocsp.ResponseStatus{ocsp.Good}, nil, true)
-		server := "http://example.com/expired_ocsp"
+		server := "http://example.fake/expired_ocsp"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: client,
 		})
@@ -195,7 +195,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 	t.Run("ocsp request roundtrip failed", func(t *testing.T) {
 		client := testhelper.MockClient([]testhelper.RSACertTuple{revokableCertTuple, revokableIssuerTuple}, []ocsp.ResponseStatus{ocsp.Good}, nil, true)
-		server := "http://example.com"
+		server := "http://example.fake"
 		serverResult := checkStatusFromServer(nil, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: client,
 		})
@@ -206,7 +206,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	})
 
 	t.Run("ocsp request roundtrip timeout", func(t *testing.T) {
-		server := "http://example.com"
+		server := "http://example.fake"
 		serverResult := checkStatusFromServer(ctx, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: &http.Client{
 				Timeout: 1 * time.Second,
@@ -224,7 +224,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 func TestPostRequest(t *testing.T) {
 	t.Run("failed to generate request", func(t *testing.T) {
-		_, err := postRequest(nil, nil, "http://example.com", &http.Client{
+		_, err := postRequest(nil, nil, "http://example.fake", &http.Client{
 			Transport: &failedTransport{},
 		})
 		expectedErrMsg := "net/http: nil Context"
@@ -234,10 +234,10 @@ func TestPostRequest(t *testing.T) {
 	})
 
 	t.Run("failed to execute request", func(t *testing.T) {
-		_, err := postRequest(context.Background(), nil, "http://example.com", &http.Client{
+		_, err := postRequest(context.Background(), nil, "http://example.fake", &http.Client{
 			Transport: &failedTransport{},
 		})
-		expectedErrMsg := "Post \"http://example.com\": failed to execute request"
+		expectedErrMsg := "Post \"http://example.fake\": failed to execute request"
 		if err == nil || err.Error() != expectedErrMsg {
 			t.Errorf("Expected error %s, but got %s", expectedErrMsg, err)
 		}

--- a/revocation/ocsp/ocsp_test.go
+++ b/revocation/ocsp/ocsp_test.go
@@ -410,13 +410,13 @@ func TestCheckStatusErrors(t *testing.T) {
 	expiredLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	expiredLeaf.IsCA = false
 	expiredLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	expiredLeaf.OCSPServer = []string{"http://example.com/expired_ocsp"}
+	expiredLeaf.OCSPServer = []string{"http://example.fake/expired_ocsp"}
 	expiredChain := []*x509.Certificate{expiredLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	noHTTPLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	noHTTPLeaf.IsCA = false
 	noHTTPLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	noHTTPLeaf.OCSPServer = []string{"ldap://ds.example.com:123/chain_ocsp/0"}
+	noHTTPLeaf.OCSPServer = []string{"ldap://ds.example.fake:123/chain_ocsp/0"}
 	noHTTPChain := []*x509.Certificate{noHTTPLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	timestampSigningCertErr := result.InvalidChainError{Err: errors.New("timestamp signing certificate with subject \"CN=Notation Test Revokable RSA Chain Cert 3,O=Notary,L=Seattle,ST=WA,C=US\" must have and only have Timestamping as extended key usage")}
@@ -633,7 +633,7 @@ func TestCheckOCSPInvalidChain(t *testing.T) {
 	for i, cert := range misorderedIntermediateChain {
 		if i != (len(misorderedIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.com/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
 		}
 	}
 
@@ -641,7 +641,7 @@ func TestCheckOCSPInvalidChain(t *testing.T) {
 	for i, cert := range missingIntermediateChain {
 		if i != (len(missingIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.com/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
 		}
 	}
 

--- a/revocation/ocsp/ocsp_test.go
+++ b/revocation/ocsp/ocsp_test.go
@@ -410,13 +410,13 @@ func TestCheckStatusErrors(t *testing.T) {
 	expiredLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	expiredLeaf.IsCA = false
 	expiredLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	expiredLeaf.OCSPServer = []string{"http://example.fake/expired_ocsp"}
+	expiredLeaf.OCSPServer = []string{"http://localhost.test/expired_ocsp"}
 	expiredChain := []*x509.Certificate{expiredLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	noHTTPLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	noHTTPLeaf.IsCA = false
 	noHTTPLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	noHTTPLeaf.OCSPServer = []string{"ldap://ds.example.fake:123/chain_ocsp/0"}
+	noHTTPLeaf.OCSPServer = []string{"ldap://ds.localhost.test:123/chain_ocsp/0"}
 	noHTTPChain := []*x509.Certificate{noHTTPLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	timestampSigningCertErr := result.InvalidChainError{Err: errors.New("timestamp signing certificate with subject \"CN=Notation Test Revokable RSA Chain Cert 3,O=Notary,L=Seattle,ST=WA,C=US\" must have and only have Timestamping as extended key usage")}
@@ -633,7 +633,7 @@ func TestCheckOCSPInvalidChain(t *testing.T) {
 	for i, cert := range misorderedIntermediateChain {
 		if i != (len(misorderedIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://localhost.test/chain_ocsp/%d", i)
 		}
 	}
 
@@ -641,7 +641,7 @@ func TestCheckOCSPInvalidChain(t *testing.T) {
 	for i, cert := range missingIntermediateChain {
 		if i != (len(missingIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://localhost.test/chain_ocsp/%d", i)
 		}
 	}
 

--- a/revocation/revocation_test.go
+++ b/revocation/revocation_test.go
@@ -823,13 +823,13 @@ func TestCheckRevocationErrors(t *testing.T) {
 	expiredLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	expiredLeaf.IsCA = false
 	expiredLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	expiredLeaf.OCSPServer = []string{"http://example.fake/expired_ocsp"}
+	expiredLeaf.OCSPServer = []string{"http://localhost.test/expired_ocsp"}
 	expiredChain := []*x509.Certificate{expiredLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	noHTTPLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	noHTTPLeaf.IsCA = false
 	noHTTPLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	noHTTPLeaf.OCSPServer = []string{"ldap://ds.example.fake:123/chain_ocsp/0"}
+	noHTTPLeaf.OCSPServer = []string{"ldap://ds.localhost.test:123/chain_ocsp/0"}
 	noHTTPChain := []*x509.Certificate{noHTTPLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	backwardsChainErr := result.InvalidChainError{Err: errors.New("leaf certificate with subject \"CN=Notation Test Revokable RSA Chain Cert Root,O=Notary,L=Seattle,ST=WA,C=US\" is self-signed. Certificate chain must not contain self-signed leaf certificate")}
@@ -984,7 +984,7 @@ func TestCheckRevocationInvalidChain(t *testing.T) {
 	for i, cert := range misorderedIntermediateChain {
 		if i != (len(misorderedIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://localhost.test/chain_ocsp/%d", i)
 		}
 	}
 
@@ -992,7 +992,7 @@ func TestCheckRevocationInvalidChain(t *testing.T) {
 	for i, cert := range missingIntermediateChain {
 		if i != (len(missingIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://localhost.test/chain_ocsp/%d", i)
 		}
 	}
 
@@ -1069,7 +1069,7 @@ func TestCRL(t *testing.T) {
 				Result: result.ResultOK,
 				ServerResults: []*result.ServerResult{{
 					Result: result.ResultOK,
-					Server: "http://example.fake/chain_crl/0",
+					Server: "http://localhost.test/chain_crl/0",
 				}},
 				RevocationMethod: result.RevocationMethodCRL,
 			},
@@ -1077,7 +1077,7 @@ func TestCRL(t *testing.T) {
 				Result: result.ResultOK,
 				ServerResults: []*result.ServerResult{{
 					Result: result.ResultOK,
-					Server: "http://example.fake/chain_crl/1",
+					Server: "http://localhost.test/chain_crl/1",
 				}},
 				RevocationMethod: result.RevocationMethodCRL,
 			},
@@ -1128,7 +1128,7 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result: result.ResultRevoked,
-						Server: "http://example.fake/chain_crl/0",
+						Server: "http://localhost.test/chain_crl/0",
 					},
 				},
 				RevocationMethod: result.RevocationMethodCRL,
@@ -1138,7 +1138,7 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result: result.ResultRevoked,
-						Server: "http://example.fake/chain_crl/1",
+						Server: "http://localhost.test/chain_crl/1",
 					},
 				},
 				RevocationMethod: result.RevocationMethodCRL,
@@ -1192,13 +1192,13 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result:           result.ResultUnknown,
-						Server:           "http://example.fake/chain_ocsp/0",
+						Server:           "http://localhost.test/chain_ocsp/0",
 						Error:            errors.New("failed to retrieve OCSP: response had status code 500"),
 						RevocationMethod: result.RevocationMethodOCSP,
 					},
 					{
 						Result:           result.ResultRevoked,
-						Server:           "http://example.fake/chain_crl/0",
+						Server:           "http://localhost.test/chain_crl/0",
 						RevocationMethod: result.RevocationMethodCRL,
 					},
 				},
@@ -1209,13 +1209,13 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result:           result.ResultUnknown,
-						Server:           "http://example.fake/chain_ocsp/1",
+						Server:           "http://localhost.test/chain_ocsp/1",
 						Error:            errors.New("failed to retrieve OCSP: response had status code 500"),
 						RevocationMethod: result.RevocationMethodOCSPFallbackCRL,
 					},
 					{
 						Result:           result.ResultRevoked,
-						Server:           "http://example.fake/chain_crl/1",
+						Server:           "http://localhost.test/chain_crl/1",
 						RevocationMethod: result.RevocationMethodCRL,
 					},
 				},
@@ -1300,8 +1300,8 @@ type crlRoundTripper struct {
 }
 
 func (rt *crlRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// e.g. ocsp URL: http://example.fake/chain_ocsp/0
-	// e.g. crl URL: http://example.fake/chain_crl/0
+	// e.g. ocsp URL: http://localhost.test/chain_ocsp/0
+	// e.g. crl URL: http://localhost.test/chain_crl/0
 	parts := strings.Split(req.URL.Path, "/")
 
 	isOCSP := parts[len(parts)-2] == "chain_ocsp"
@@ -1311,7 +1311,7 @@ func (rt *crlRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	// choose the cert suffix based on suffix of request url
-	// e.g. http://example.fake/chain_crl/0 -> 0
+	// e.g. http://localhost.test/chain_crl/0 -> 0
 	i, err := strconv.Atoi(parts[len(parts)-1])
 	if err != nil {
 		return nil, err

--- a/revocation/revocation_test.go
+++ b/revocation/revocation_test.go
@@ -823,13 +823,13 @@ func TestCheckRevocationErrors(t *testing.T) {
 	expiredLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	expiredLeaf.IsCA = false
 	expiredLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	expiredLeaf.OCSPServer = []string{"http://example.com/expired_ocsp"}
+	expiredLeaf.OCSPServer = []string{"http://example.fake/expired_ocsp"}
 	expiredChain := []*x509.Certificate{expiredLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	noHTTPLeaf, _ := x509.ParseCertificate(revokableTuples[0].Cert.Raw)
 	noHTTPLeaf.IsCA = false
 	noHTTPLeaf.KeyUsage = x509.KeyUsageDigitalSignature
-	noHTTPLeaf.OCSPServer = []string{"ldap://ds.example.com:123/chain_ocsp/0"}
+	noHTTPLeaf.OCSPServer = []string{"ldap://ds.example.fake:123/chain_ocsp/0"}
 	noHTTPChain := []*x509.Certificate{noHTTPLeaf, revokableTuples[1].Cert, revokableTuples[2].Cert}
 
 	backwardsChainErr := result.InvalidChainError{Err: errors.New("leaf certificate with subject \"CN=Notation Test Revokable RSA Chain Cert Root,O=Notary,L=Seattle,ST=WA,C=US\" is self-signed. Certificate chain must not contain self-signed leaf certificate")}
@@ -984,7 +984,7 @@ func TestCheckRevocationInvalidChain(t *testing.T) {
 	for i, cert := range misorderedIntermediateChain {
 		if i != (len(misorderedIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.com/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
 		}
 	}
 
@@ -992,7 +992,7 @@ func TestCheckRevocationInvalidChain(t *testing.T) {
 	for i, cert := range missingIntermediateChain {
 		if i != (len(missingIntermediateChain) - 1) {
 			// Skip root which won't have an OCSP Server
-			cert.OCSPServer[0] = fmt.Sprintf("http://example.com/chain_ocsp/%d", i)
+			cert.OCSPServer[0] = fmt.Sprintf("http://example.fake/chain_ocsp/%d", i)
 		}
 	}
 
@@ -1069,7 +1069,7 @@ func TestCRL(t *testing.T) {
 				Result: result.ResultOK,
 				ServerResults: []*result.ServerResult{{
 					Result: result.ResultOK,
-					Server: "http://example.com/chain_crl/0",
+					Server: "http://example.fake/chain_crl/0",
 				}},
 				RevocationMethod: result.RevocationMethodCRL,
 			},
@@ -1077,7 +1077,7 @@ func TestCRL(t *testing.T) {
 				Result: result.ResultOK,
 				ServerResults: []*result.ServerResult{{
 					Result: result.ResultOK,
-					Server: "http://example.com/chain_crl/1",
+					Server: "http://example.fake/chain_crl/1",
 				}},
 				RevocationMethod: result.RevocationMethodCRL,
 			},
@@ -1128,7 +1128,7 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result: result.ResultRevoked,
-						Server: "http://example.com/chain_crl/0",
+						Server: "http://example.fake/chain_crl/0",
 					},
 				},
 				RevocationMethod: result.RevocationMethodCRL,
@@ -1138,7 +1138,7 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result: result.ResultRevoked,
-						Server: "http://example.com/chain_crl/1",
+						Server: "http://example.fake/chain_crl/1",
 					},
 				},
 				RevocationMethod: result.RevocationMethodCRL,
@@ -1192,13 +1192,13 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result:           result.ResultUnknown,
-						Server:           "http://example.com/chain_ocsp/0",
+						Server:           "http://example.fake/chain_ocsp/0",
 						Error:            errors.New("failed to retrieve OCSP: response had status code 500"),
 						RevocationMethod: result.RevocationMethodOCSP,
 					},
 					{
 						Result:           result.ResultRevoked,
-						Server:           "http://example.com/chain_crl/0",
+						Server:           "http://example.fake/chain_crl/0",
 						RevocationMethod: result.RevocationMethodCRL,
 					},
 				},
@@ -1209,13 +1209,13 @@ func TestCRL(t *testing.T) {
 				ServerResults: []*result.ServerResult{
 					{
 						Result:           result.ResultUnknown,
-						Server:           "http://example.com/chain_ocsp/1",
+						Server:           "http://example.fake/chain_ocsp/1",
 						Error:            errors.New("failed to retrieve OCSP: response had status code 500"),
 						RevocationMethod: result.RevocationMethodOCSPFallbackCRL,
 					},
 					{
 						Result:           result.ResultRevoked,
-						Server:           "http://example.com/chain_crl/1",
+						Server:           "http://example.fake/chain_crl/1",
 						RevocationMethod: result.RevocationMethodCRL,
 					},
 				},
@@ -1300,8 +1300,8 @@ type crlRoundTripper struct {
 }
 
 func (rt *crlRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// e.g. ocsp URL: http://example.com/chain_ocsp/0
-	// e.g. crl URL: http://example.com/chain_crl/0
+	// e.g. ocsp URL: http://example.fake/chain_ocsp/0
+	// e.g. crl URL: http://example.fake/chain_crl/0
 	parts := strings.Split(req.URL.Path, "/")
 
 	isOCSP := parts[len(parts)-2] == "chain_ocsp"
@@ -1311,7 +1311,7 @@ func (rt *crlRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	// choose the cert suffix based on suffix of request url
-	// e.g. http://example.com/chain_crl/0 -> 0
+	// e.g. http://example.fake/chain_crl/0 -> 0
 	i, err := strconv.Atoi(parts[len(parts)-1])
 	if err != nil {
 		return nil, err

--- a/revocation/revocation_test.go
+++ b/revocation/revocation_test.go
@@ -1164,7 +1164,9 @@ func TestCRL(t *testing.T) {
 		}
 
 		revocationClient, err := NewWithOptions(Options{
-			OCSPHTTPClient:   &http.Client{},
+			OCSPHTTPClient: &http.Client{
+				Transport: &serverErrorTransport{},
+			},
 			CRLFetcher:       fetcher,
 			CertChainPurpose: purpose.CodeSigning,
 		})
@@ -1350,6 +1352,15 @@ type panicTransport struct{}
 
 func (t panicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	panic("panic")
+}
+
+type serverErrorTransport struct{}
+
+func (t serverErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(bytes.NewReader([]byte{})),
+	}, nil
 }
 
 func TestValidateContext(t *testing.T) {

--- a/testhelper/certificatetest.go
+++ b/testhelper/certificatetest.go
@@ -182,7 +182,7 @@ func getRSACertTuple(cn string, issuer *RSACertTuple) RSACertTuple {
 
 func getRevokableRSACertTuple(cn string, issuer *RSACertTuple) RSACertTuple {
 	template := getCertTemplate(issuer == nil, true, false, cn)
-	template.OCSPServer = []string{"http://example.com/ocsp"}
+	template.OCSPServer = []string{"http://example.fake/ocsp"}
 	return getRSACertTupleWithTemplate(template, issuer.PrivateKey, issuer)
 }
 
@@ -192,11 +192,11 @@ func getRevokableRSAChainCertTuple(cn string, previous *RSACertTuple, index int,
 	template.IsCA = true
 	template.KeyUsage = x509.KeyUsageCertSign
 	if enabledOCSP {
-		template.OCSPServer = []string{fmt.Sprintf("http://example.com/chain_ocsp/%d", index)}
+		template.OCSPServer = []string{fmt.Sprintf("http://example.fake/chain_ocsp/%d", index)}
 	}
 	if enabledCRL {
 		template.KeyUsage |= x509.KeyUsageCRLSign
-		template.CRLDistributionPoints = []string{fmt.Sprintf("http://example.com/chain_crl/%d", index)}
+		template.CRLDistributionPoints = []string{fmt.Sprintf("http://example.fake/chain_crl/%d", index)}
 	}
 	return getRSACertTupleWithTemplate(template, previous.PrivateKey, previous)
 }
@@ -220,10 +220,10 @@ func getRevokableRSALeafChainCertTuple(cn string, issuer *RSACertTuple, index in
 	template.IsCA = false
 	template.KeyUsage = x509.KeyUsageDigitalSignature
 	if enabledOCSP {
-		template.OCSPServer = []string{fmt.Sprintf("http://example.com/chain_ocsp/%d", index)}
+		template.OCSPServer = []string{fmt.Sprintf("http://example.fake/chain_ocsp/%d", index)}
 	}
 	if enabledCRL {
-		template.CRLDistributionPoints = []string{fmt.Sprintf("http://example.com/chain_crl/%d", index)}
+		template.CRLDistributionPoints = []string{fmt.Sprintf("http://example.fake/chain_crl/%d", index)}
 	}
 	return getRSACertTupleWithTemplate(template, issuer.PrivateKey, issuer)
 }

--- a/testhelper/certificatetest.go
+++ b/testhelper/certificatetest.go
@@ -182,7 +182,7 @@ func getRSACertTuple(cn string, issuer *RSACertTuple) RSACertTuple {
 
 func getRevokableRSACertTuple(cn string, issuer *RSACertTuple) RSACertTuple {
 	template := getCertTemplate(issuer == nil, true, false, cn)
-	template.OCSPServer = []string{"http://example.fake/ocsp"}
+	template.OCSPServer = []string{"http://localhost.test/ocsp"}
 	return getRSACertTupleWithTemplate(template, issuer.PrivateKey, issuer)
 }
 
@@ -192,11 +192,11 @@ func getRevokableRSAChainCertTuple(cn string, previous *RSACertTuple, index int,
 	template.IsCA = true
 	template.KeyUsage = x509.KeyUsageCertSign
 	if enabledOCSP {
-		template.OCSPServer = []string{fmt.Sprintf("http://example.fake/chain_ocsp/%d", index)}
+		template.OCSPServer = []string{fmt.Sprintf("http://localhost.test/chain_ocsp/%d", index)}
 	}
 	if enabledCRL {
 		template.KeyUsage |= x509.KeyUsageCRLSign
-		template.CRLDistributionPoints = []string{fmt.Sprintf("http://example.fake/chain_crl/%d", index)}
+		template.CRLDistributionPoints = []string{fmt.Sprintf("http://localhost.test/chain_crl/%d", index)}
 	}
 	return getRSACertTupleWithTemplate(template, previous.PrivateKey, previous)
 }
@@ -220,10 +220,10 @@ func getRevokableRSALeafChainCertTuple(cn string, issuer *RSACertTuple, index in
 	template.IsCA = false
 	template.KeyUsage = x509.KeyUsageDigitalSignature
 	if enabledOCSP {
-		template.OCSPServer = []string{fmt.Sprintf("http://example.fake/chain_ocsp/%d", index)}
+		template.OCSPServer = []string{fmt.Sprintf("http://localhost.test/chain_ocsp/%d", index)}
 	}
 	if enabledCRL {
-		template.CRLDistributionPoints = []string{fmt.Sprintf("http://example.fake/chain_crl/%d", index)}
+		template.CRLDistributionPoints = []string{fmt.Sprintf("http://localhost.test/chain_crl/%d", index)}
 	}
 	return getRSACertTupleWithTemplate(template, issuer.PrivateKey, issuer)
 }


### PR DESCRIPTION
Fix:
- added mocked HTTP client for a test case of revocation package
- replaced `*.com` with `*.test` to avoid mentioning a real domain in testing URL

NOTE: `.test` is a reserved domain for testing in RFC 2606