### PR TITLE
fix: `check-line-endings` command of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ clean:
 .PHONY: check-line-endings
 check-line-endings: ## check line endings
 	! find . -name "*.go" -type f -exec file "{}" ";" | grep CRLF
+	! find . -name "*.sh" -type f -exec file "{}" ";" | grep CRLF
 
 .PHONY: fix-line-endings
 fix-line-endings: ## fix line endings

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ clean:
 .PHONY: check-line-endings
 check-line-endings: ## check line endings
 	! find . -name "*.go" -type f -exec file "{}" ";" | grep CRLF
-	! find scripts -name "*.sh" -type f -exec file "{}" ";" | grep CRLF
 
 .PHONY: fix-line-endings
 fix-line-endings: ## fix line endings


### PR DESCRIPTION
Fix:
- update the command to search script file in `.` instead of `scripts/` folder to avoid returning an error.