### PR TITLE
fix linter warnings in test files

### DIFF
--- a/revocation/internal/ocsp/ocsp_test.go
+++ b/revocation/internal/ocsp/ocsp_test.go
@@ -196,6 +196,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 	t.Run("ocsp request roundtrip failed", func(t *testing.T) {
 		client := testhelper.MockClient([]testhelper.RSACertTuple{revokableCertTuple, revokableIssuerTuple}, []ocsp.ResponseStatus{ocsp.Good}, nil, true)
 		server := "http://localhost.test"
+		//lint:ignore SA1012 nil context is used for testing
 		serverResult := checkStatusFromServer(nil, revokableCertTuple.Cert, revokableIssuerTuple.Cert, server, CertCheckStatusOptions{
 			HTTPClient: client,
 		})
@@ -224,6 +225,7 @@ func TestCheckStatusFromServer(t *testing.T) {
 
 func TestPostRequest(t *testing.T) {
 	t.Run("failed to generate request", func(t *testing.T) {
+		//lint:ignore SA1012 nil context is used for testing
 		_, err := postRequest(nil, nil, "http://localhost.test", &http.Client{
 			Transport: &failedTransport{},
 		})

--- a/signature/types_test.go
+++ b/signature/types_test.go
@@ -50,6 +50,7 @@ func TestSignRequestWithContext(t *testing.T) {
 			t.Errorf("expected to be panic")
 		}
 	}()
+	//lint:ignore SA1012 nil context is used for testing
 	r.WithContext(nil) // should panic
 }
 


### PR DESCRIPTION
This PR introduces following change:

- `staticcheck` linter will ignore checks in test files in test cases where `nil` value is passed on purpose

This PR addresses partially https://github.com/notaryproject/notation-core-go/issues/270#event-17445145816
